### PR TITLE
Fixed bug in password to-char-array

### DIFF
--- a/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/network/PMqtt.java
+++ b/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/network/PMqtt.java
@@ -61,7 +61,7 @@ public class PMqtt extends ProtoBase {
 
             if (connectionSettings.containsKey("user") && connectionSettings.containsKey("password")) {
                 connOpts.setUserName((String) connectionSettings.get("user"));
-                connOpts.setPassword(connectionSettings.get("password").toCharArray());
+                connOpts.setPassword(((String)connectionSettings.get("password")).toCharArray());
             }
 
             connOpts.setCleanSession(true);

--- a/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/network/PMqtt.java
+++ b/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/network/PMqtt.java
@@ -61,7 +61,7 @@ public class PMqtt extends ProtoBase {
 
             if (connectionSettings.containsKey("user") && connectionSettings.containsKey("password")) {
                 connOpts.setUserName((String) connectionSettings.get("user"));
-                connOpts.setPassword((char[]) connectionSettings.get("password"));
+                connOpts.setPassword(connectionSettings.get("password").toCharArray());
             }
 
             connOpts.setCleanSession(true);


### PR DESCRIPTION
The cast to (char[]) will always fail for String. The String class has the method "toCharArray()" to do the conversion. Note that the MQTT example uses the key "username" instead of "user".