### PR TITLE
Fix and minor changes regarding MTU in `network.bluetoothLE`

### DIFF
--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/network/PBluetoothLEClient.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/network/PBluetoothLEClient.java
@@ -67,6 +67,8 @@ public class PBluetoothLEClient extends ProtoBase implements WhatIsRunningInterf
     private BluetoothGatt mGatt;
     private ReturnInterface mCallbackDevice;
     private ReturnInterface mCallbackCharacteristic;
+    private int mtuSize = 500;
+    private ReturnInterface mCallbackMtu;
     // Callback for peripherals
     private final BluetoothPeripheralCallback peripheralCallback = new BluetoothPeripheralCallback() {
         @Override
@@ -178,13 +180,26 @@ public class PBluetoothLEClient extends ProtoBase implements WhatIsRunningInterf
         ) {
             MLog.d(TAG, "onCharWrite");
         }
+
+        @Override
+        public void onMtuChanged(BluetoothPeripheral peripheral, int mtu, int status) {
+            ReturnObject ret = new ReturnObject();
+            ret.put("deviceMac", peripheral.getAddress());
+            ret.put("deviceName", peripheral.getName());
+            ret.put("mtu", mtu);
+            ret.put("success", status == GATT_SUCCESS);
+
+            mHandler.post(() -> {
+                if (mCallbackMtu != null) mCallbackMtu.event(ret);
+            });
+        }
     };
     // Callback for central
     private final BluetoothCentralCallback bluetoothCentralCallback = new BluetoothCentralCallback() {
 
         @Override
         public void onConnectedPeripheral(BluetoothPeripheral peripheral) {
-            peripheral.requestMtu(500);
+            peripheral.requestMtu(mtuSize);
 
             MLog.d(TAG, "connected to '%s' " + peripheral.getName());
             ReturnObject ret = new ReturnObject();
@@ -204,6 +219,13 @@ public class PBluetoothLEClient extends ProtoBase implements WhatIsRunningInterf
         @Override
         public void onDisconnectedPeripheral(final BluetoothPeripheral peripheral, final int status) {
             MLog.d(TAG, "disconnected '%s' with status %d" + " " + peripheral.getName() + " " + status);
+            ReturnObject ret = new ReturnObject();
+            ret.put("deviceMac", peripheral.getAddress());
+            ret.put("deviceName", peripheral.getAddress());
+            ret.put("status", "disconnected");
+            mHandler.post(() -> {
+                if (mCallbackDevice != null) mCallbackDevice.event(ret);
+            });
 
             // Reconnect to this device when it becomes available again if autoConnect is true
             if (!autoConnect) return;
@@ -248,12 +270,8 @@ public class PBluetoothLEClient extends ProtoBase implements WhatIsRunningInterf
     }
 
     public PBluetoothLEClient connectDevice(String macAddress, int mtuSize) {
-        BluetoothPeripheral peripheral = central.getPeripheral(macAddress);
-        peripheral.requestConnectionPriority(CONNECTION_PRIORITY_HIGH);
-        peripheral.requestMtu(mtuSize);
-        central.connectPeripheral(peripheral, peripheralCallback);
-
-        return this;
+        this.mtuSize = mtuSize;
+        return this.connectDevice(macAddress);
     }
 
     public PBluetoothLEClient autoConnect(boolean autoConnect) {
@@ -285,6 +303,11 @@ public class PBluetoothLEClient extends ProtoBase implements WhatIsRunningInterf
 
     public PBluetoothLEClient onNewData(ReturnInterface callback) {
         mCallbackCharacteristic = callback;
+        return this;
+    }
+
+    public PBluetoothLEClient onMtuChanged(ReturnInterface callback) {
+        this.mCallbackMtu = callback;
         return this;
     }
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/network/PBluetoothLEClient.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/network/PBluetoothLEClient.java
@@ -312,6 +312,10 @@ public class PBluetoothLEClient extends ProtoBase implements WhatIsRunningInterf
     }
 
     public PBluetoothLEClient write(String value, String macAddress, String serviceUUID, String charUUID) {
+      return this._write(value.getBytes(), macAddress, serviceUUID, charUUID);
+    }
+
+    public PBluetoothLEClient _write(byte[] bytes, String macAddress, String serviceUUID, String charUUID) {
         BluetoothPeripheral peripheral = central.getPeripheral(macAddress);
 
         UUID sUUID = UUID.fromString(serviceUUID);
@@ -319,7 +323,7 @@ public class PBluetoothLEClient extends ProtoBase implements WhatIsRunningInterf
         BluetoothGattCharacteristic btChar = peripheral.getCharacteristic(sUUID, cUUID);
 
         // peripheral.writeCharacteristic(btChar, value, type);
-        peripheral.writeCharacteristic(btChar, value.getBytes(), WRITE_TYPE_DEFAULT);
+        peripheral.writeCharacteristic(btChar, bytes, WRITE_TYPE_DEFAULT);
 
         return this;
     }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/sensors/PLocation.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/sensors/PLocation.java
@@ -217,15 +217,15 @@ public class PLocation extends ProtoBase {
                 satItem.put("prn", sat.getPrn());
                 satItem.put("snr", sat.getSnr());
                 sats.add(satItem);
-
-                ReturnObject ret = new ReturnObject();
-                ret.put("satellites", sats);
-                ret.put("satellitesInView", satellitesCount);
-                ret.put("satellitesInFix", satellitesInFix);
-
-                if (mSatellitesCallback != null) mSatellitesCallback.event(ret);
             }
             // MLog.d(TAG, satellitesCount + " Used In Last Fix ("+satellitesInFix+")");
+
+            ReturnObject ret = new ReturnObject();
+            ret.put("satellites", sats);
+            ret.put("satellitesInView", satellitesCount);
+            ret.put("satellitesInFix", satellitesInFix);
+
+            if (mSatellitesCallback != null) mSatellitesCallback.event(ret);
         });
     }
 


### PR DESCRIPTION
Hi,

`peripheral.requestMtu` doesn't do anything if not connected, see https://github.com/weliem/blessed-android/blob/ee8d966692a233457ed8ac967ba37a5ef9d69630/blessed/src/main/java/com/welie/blessed/BluetoothPeripheral.java#L1541
Therefore, `mtuSize` of `connectDevice` is essentially ignored.

This PR fixes this issue and additionally exposes two events: disconnect and MTU changed

Feel free to adjust code style if not appropriate