### PR TITLE
Partial revert of #141 and improved properties

### DIFF
--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PUI.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PUI.java
@@ -53,7 +53,7 @@ import io.phonk.runner.apprunner.api.common.ReturnObject;
 import io.phonk.runner.apprunner.api.widgets.PPopupDialogFragment;
 import io.phonk.runner.apprunner.api.widgets.PToolbar;
 import io.phonk.runner.apprunner.api.widgets.PViewMethodsInterface;
-import io.phonk.runner.apprunner.api.widgets.StylePropertiesProxy;
+import io.phonk.runner.apprunner.api.widgets.PropertiesProxy;
 import io.phonk.runner.apprunner.api.widgets.WidgetHelper;
 import io.phonk.runner.apprunner.interpreter.PhonkNativeArray;
 import io.phonk.runner.base.utils.AndroidUtils;
@@ -61,9 +61,9 @@ import io.phonk.runner.base.utils.MLog;
 
 @PhonkObject(mergeFrom = "ViewsArea")
 public class PUI extends PViewsArea {
-    public final StylePropertiesProxy rootStyle = new StylePropertiesProxy();
+    public final PropertiesProxy rootProps = new PropertiesProxy();
     public final ArrayList viewTree = new ArrayList<ViewElement>();
-    public StylePropertiesProxy theme;
+    public PropertiesProxy theme;
     public View mainLayout;
     public int screenWidth;
     public int screenHeight;
@@ -114,7 +114,7 @@ public class PUI extends PViewsArea {
 
     @SuppressLint("ResourceType")
     private void setTheme() {
-        theme = new StylePropertiesProxy();
+        theme = new PropertiesProxy();
 
         theme.put("background", getContext().getResources().getString(R.color.phonk_backgroundColor));
         theme.put("primary", getContext().getResources().getString(R.color.phonk_colorPrimary));
@@ -139,28 +139,29 @@ public class PUI extends PViewsArea {
         String colorBackground = (String) theme.get("background");
         String colorTransparent = "#00FFFFFF";
 
-        rootStyle.put("opacity", rootStyle, 1.0f);
+        rootProps.put("x", rootProps, 0f);
+        rootProps.put("y", rootProps, 0f);
+        rootProps.put("w", rootProps, 0.2f);
+        rootProps.put("h", rootProps, 0.2f);
 
-        rootStyle.put("background", rootStyle, colorPrimaryShade);
-        rootStyle.put("backgroundHover", rootStyle, "#88000000");
-        rootStyle.put("backgroundPressed", rootStyle, "#33FFFFFF");
-        rootStyle.put("backgroundSelected", rootStyle, "#88000000");
-        rootStyle.put("backgroundChecked", rootStyle, "#88000000");
+        rootProps.put("opacity", rootProps, 1.0f);
 
-        rootStyle.put("borderColor", rootStyle, colorTransparent);
-        rootStyle.put("borderWidth", rootStyle, 0);
-        rootStyle.put("borderRadius", rootStyle, 20); // set to 20
+        rootProps.put("background", rootProps, colorPrimaryShade);
+        rootProps.put("backgroundHover", rootProps, "#88000000");
+        rootProps.put("backgroundPressed", rootProps, "#33FFFFFF");
+        rootProps.put("backgroundSelected", rootProps, "#88000000");
+        rootProps.put("backgroundChecked", rootProps, "#88000000");
 
-        rootStyle.put("src", rootStyle, "");
-        rootStyle.put("srcPressed", rootStyle, "");
+        rootProps.put("borderColor", rootProps, colorTransparent);
+        rootProps.put("borderWidth", rootProps, 0);
+        rootProps.put("borderRadius", rootProps, 20); // set to 20
 
-        rootStyle.put("textColor", rootStyle, colorTextPrimary);
-        rootStyle.put("textSize", rootStyle, 16);
-        rootStyle.put("textFont", rootStyle, "monospace");
-        rootStyle.put("textStyle", rootStyle, "normal");
-        rootStyle.put("textAlign", rootStyle, "center");
-        rootStyle.put("textTransform", rootStyle, "none");
-        rootStyle.put("padding", rootStyle, AndroidUtils.dpToPixels(getContext(), 2));
+        rootProps.put("textColor", rootProps, colorTextPrimary);
+        rootProps.put("textSize", rootProps, 16);
+        rootProps.put("textFont", rootProps, "monospace");
+        rootProps.put("textStyle", rootProps, "normal");
+        rootProps.put("textAlign", rootProps, "center");
+        rootProps.put("padding", rootProps, AndroidUtils.dpToPixels(getContext(), 2));
         /*
         rootStyle.put("paddingLeft", rootStyle, AndroidUtils.dpToPixels(getContext(), 2));
         rootStyle.put("paddingTop", rootStyle, AndroidUtils.dpToPixels(getContext(), 2));
@@ -206,8 +207,8 @@ public class PUI extends PViewsArea {
         return pViewsArea;
     }
 
-    public StylePropertiesProxy getStyle() {
-        return rootStyle;
+    public PropertiesProxy getProps() {
+        return rootProps;
     }
 
     public void screenMode(String mode) {
@@ -547,12 +548,13 @@ public class PUI extends PViewsArea {
         return AndroidUtils.takeScreenshotView(v);
     }
 
-    public View getViewById(int id) {
+    public View getViewById(String id) {
         ArrayList<View> views = ((PViewsArea) (viewTree.get(0))).viewArray;
 
         for (View v : views) {
             PViewMethodsInterface vmi = (PViewMethodsInterface) v;
-            if (vmi.id() == id) {
+            String viewId = (String) vmi.getProps().get("id");
+            if (id.equals(viewId)) {
                 return v;
             }
         }
@@ -574,7 +576,7 @@ public class PUI extends PViewsArea {
 
             if (o instanceof PViewMethodsInterface) {
                 Map props = ((PViewMethodsInterface) o).getProps();
-                ReturnObject returnObject = ((StylePropertiesProxy) props).values;
+                ReturnObject returnObject = ((PropertiesProxy) props).values;
                 ob.put("props", returnObject);
             } else if (o.getClass().getSimpleName().equals("PViewsArea") || o.getClass()
                     .getSimpleName()

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PUI.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PUI.java
@@ -105,15 +105,15 @@ public class PUI extends PViewsArea {
 
         isMainLayoutSetup = true;
 
-        setTheme();
-        setStyle();
-        background((String) theme.get("background"));
+        initializeProps();
+        initializeTheme();
+        theme.change();
 
         viewTree.add(this);
     }
 
     @SuppressLint("ResourceType")
-    private void setTheme() {
+    private void initializeTheme() {
         theme = new PropertiesProxy();
 
         theme.put("background", getContext().getResources().getString(R.color.phonk_backgroundColor));
@@ -126,52 +126,64 @@ public class PUI extends PViewsArea {
 
         // if the theme is change then we reapply the styles
         theme.onChange((name, value) -> {
-            setStyle();
+            setStyle(name, value);
         });
     }
 
-    private void setStyle() {
-        String colorPrimary = (String) theme.get("primary");
-        String colorPrimaryShade = (String) theme.get("primaryShade");
-        String colorSecondary = (String) theme.get("secondary");
-        String colorSecondaryShade = (String) theme.get("secondaryShade");
-        String colorTextPrimary = (String) theme.get("textPrimary");
-        String colorBackground = (String) theme.get("background");
+    private void initializeProps() {
         String colorTransparent = "#00FFFFFF";
 
-        rootProps.put("x", rootProps, 0f);
-        rootProps.put("y", rootProps, 0f);
-        rootProps.put("w", rootProps, 0.2f);
-        rootProps.put("h", rootProps, 0.2f);
+        rootProps.put("x", 0f);
+        rootProps.put("y", 0f);
+        rootProps.put("w", 0.2f);
+        rootProps.put("h", 0.2f);
 
-        rootProps.put("opacity", rootProps, 1.0f);
+        rootProps.put("visibility", "visible");
+        rootProps.put("enabled", true);
+        rootProps.put("opacity", 1.0f);
 
-        rootProps.put("background", rootProps, colorPrimaryShade);
-        rootProps.put("backgroundHover", rootProps, "#88000000");
-        rootProps.put("backgroundPressed", rootProps, "#33FFFFFF");
-        rootProps.put("backgroundSelected", rootProps, "#88000000");
-        rootProps.put("backgroundChecked", rootProps, "#88000000");
+        rootProps.put("backgroundHover", "#88000000");
+        rootProps.put("backgroundPressed", "#33FFFFFF");
+        rootProps.put("backgroundSelected", "#88000000");
+        rootProps.put("backgroundChecked", "#88000000");
 
-        rootProps.put("borderColor", rootProps, colorTransparent);
-        rootProps.put("borderWidth", rootProps, 0);
-        rootProps.put("borderRadius", rootProps, 20); // set to 20
+        rootProps.put("borderColor", colorTransparent);
+        rootProps.put("borderWidth", 0);
+        rootProps.put("borderRadius", 20); // set to 20
 
-        rootProps.put("textColor", rootProps, colorTextPrimary);
-        rootProps.put("textSize", rootProps, 16);
-        rootProps.put("textFont", rootProps, "monospace");
-        rootProps.put("textStyle", rootProps, "normal");
-        rootProps.put("textAlign", rootProps, "center");
-        rootProps.put("padding", rootProps, AndroidUtils.dpToPixels(getContext(), 2));
-        /*
-        rootStyle.put("paddingLeft", rootStyle, AndroidUtils.dpToPixels(getContext(), 2));
-        rootStyle.put("paddingTop", rootStyle, AndroidUtils.dpToPixels(getContext(), 2));
-        rootStyle.put("paddingRight", rootStyle, AndroidUtils.dpToPixels(getContext(), 2));
-        rootStyle.put("paddingBottom", rootStyle, AndroidUtils.dpToPixels(getContext(), 2));
-         */
+        rootProps.put("textSize", 16);
+        rootProps.put("textFont", "monospace");
+        rootProps.put("textStyle", "normal");
+        rootProps.put("textAlign", "center");
+        rootProps.put("padding", AndroidUtils.dpToPixels(getContext(), 2));
+    }
 
-        // style.put("animInBefore", style, "this.x(0).y(100)");
-        // style.put("animIn", style, "this.animate().x(100)");
-        // style.put("animOut", style, "this.animate().x(0)");
+    private void setStyle(String name, Object value) {
+        if (name == null) {
+            setStyle("background");
+            setStyle("primaryShade");
+            setStyle("textPrimary");
+
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "background":
+                    background(value.toString());
+                    break;
+
+                case "primaryShade":
+                    rootProps.put("background", value);
+                    break;
+
+                case "textPrimary":
+                    rootProps.put("textColor", value);
+                    break;
+            }
+        }
+    }
+
+    private void setStyle(String name) {
+        setStyle(name, theme.get(name));
     }
 
     @Override
@@ -262,13 +274,7 @@ public class PUI extends PViewsArea {
      */
     @PhonkMethod
     public void setTheme(Map<String, Object> properties) {
-        theme.eventOnChange = false;
-        for (Map.Entry<String, Object> entry : properties.entrySet()) {
-            theme.put(entry.getKey(), theme, entry.getValue());
-        }
-        setStyle();
-        background((String) theme.get("background"));
-        theme.eventOnChange = true;
+        WidgetHelper.setProps(theme, properties);
     }
 
     /**
@@ -278,7 +284,7 @@ public class PUI extends PViewsArea {
      */
     @PhonkMethod
     public void addTitle(String title) {
-        getFragment().changeTitle(title, (String) theme.get("primary"));
+        getFragment().changeTitle(title, theme.get("primary").toString());
     }
 
     /**

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PUtil.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PUtil.java
@@ -260,8 +260,10 @@ public class PUtil extends ProtoBase {
             String type = splitted[1];
 
             returnVal = transform(type, value, toValue);
-        } else if (val instanceof Double) {
-            returnVal = transform("", (Double) val, toValue);
+        } else if (val instanceof Number) {
+            Double doubleVal = ((Number) val).doubleValue();
+            if (doubleVal < 0 && doubleVal.intValue() == doubleVal) return doubleVal.intValue();
+            returnVal = transform("", doubleVal, toValue);
         }
 
         return returnVal;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PViewsArea.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PViewsArea.java
@@ -636,9 +636,7 @@ public class PViewsArea extends ProtoBase {
      */
     @PhonkMethod
     public PImage addImage(Object x, Object y) {
-        final PImage iv = (PImage) newView("image");
-        addView(iv, x, y, -1, -1);
-        return iv;
+        return addImage(x, y, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     }
 
     @PhonkMethod
@@ -650,10 +648,7 @@ public class PViewsArea extends ProtoBase {
 
     @PhonkMethod
     public PImage addImage(String imagePath, Object x, Object y) {
-        PImage iv = (PImage) newView("image");
-        iv.load(imagePath);
-        addView(iv, x, y, -1, -1);
-        return iv;
+        return addImage(imagePath, x, y, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     }
 
     @PhonkMethod
@@ -909,10 +904,7 @@ public class PViewsArea extends ProtoBase {
      */
     @PhonkMethod
     public PLinearLayout addLinearLayout(Object x, Object y) {
-        PLinearLayout pLinearLayout = (PLinearLayout) newView("linearLayout");
-        addView(pLinearLayout, x, y, -1, -1);
-
-        return pLinearLayout;
+        return addLinearLayout(x, y, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     }
 
     @PhonkMethod

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PViewsArea.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PViewsArea.java
@@ -284,7 +284,7 @@ public class PViewsArea extends ProtoBase {
     @PhonkMethod
     public PButton addButton(String label, Object x, Object y, Object w, Object h) {
         PButton b = (PButton) newView("button");
-        b.text(label);
+        b.props.put("text", label);
         addView(b, x, y, w, h);
         return b;
     }
@@ -349,10 +349,7 @@ public class PViewsArea extends ProtoBase {
 
     @PhonkMethod
     public PButton addButton(String label, Object x, Object y) {
-        PButton b = (PButton) newView("button");
-        b.text(label);
-        addView(b, x, y, -1, -1);
-        return b;
+        return addButton(label, x, y, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     }
 
     /**
@@ -409,10 +406,7 @@ public class PViewsArea extends ProtoBase {
      */
     @PhonkMethod
     public PImageButton addImageButton(String imagePath, Object x, Object y) {
-        PImageButton pImageButton = (PImageButton) newView("imageButton");
-        pImageButton.load(imagePath);
-        addView(pImageButton, x, y, -1, -1);
-        return pImageButton;
+        return addImageButton(imagePath, x, y, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     }
 
     /**
@@ -429,30 +423,23 @@ public class PViewsArea extends ProtoBase {
     @PhonkMethod(description = "", example = "")
     @PhonkMethodParam(params = {"label", "x", "y"})
     public PText addText(Object x, Object y) {
-        PText tv = (PText) newView("text");
-        addView(tv, x, y, -1, -1);
-        return tv;
+        return addText("", x, y);
     }
 
     @PhonkMethod
     public PText addText(Object x, Object y, Object w, Object h) {
-        PText tv = (PText) newView("text");
-        addView(tv, x, y, w, h);
-        return tv;
+        return addText("", x, y, w, h);
     }
 
     @PhonkMethod
     public PText addText(String text, Object x, Object y) {
-        PText tv = (PText) newView("text");
-        tv.text(text);
-        addView(tv, x, y, -1, -1);
-        return tv;
+        return addText(text, x, y, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     }
 
     @PhonkMethod
     public PText addText(String label, Object x, Object y, Object w, Object h) {
         PText tv = (PText) newView("text");
-        tv.text(label);
+        tv.props.put("text", label);
         addView(tv, x, y, w, h);
         return tv;
     }
@@ -507,17 +494,17 @@ public class PViewsArea extends ProtoBase {
         PToggle t = (PToggle) newView("toggle");
 
         if (text.length == 1) {
-            t.text(text[0]);
-            t.textOn(text[0]);
-            t.textOff(text[0]);
+            t.props.put("text", text[0]);
+            t.props.put("textOn", text[0]);
+            t.props.put("textOff", text[0]);
         } else if (text.length == 2) {
-            t.text(text[0]);
-            t.textOn(text[1]);
-            t.textOff(text[0]);
+            t.props.put("text", text[0]);
+            t.props.put("textOn", text[1]);
+            t.props.put("textOff", text[0]);
         } else if (text.length == 3) {
-            t.text(text[0]);
-            t.textOn(text[1]);
-            t.textOff(text[2]);
+            t.props.put("text", text[0]);
+            t.props.put("textOn", text[1]);
+            t.props.put("textOff", text[2]);
         }
 
         addView(t, x, y, w, h);
@@ -615,7 +602,7 @@ public class PViewsArea extends ProtoBase {
     @PhonkMethod
     public PLoader addLoader(Object x, Object y, Object w, Object h) {
         PLoader pb = (PLoader) newView("loader");
-        addView(pb, x, y, w, -1);
+        addView(pb, x, y, w, ViewGroup.LayoutParams.WRAP_CONTENT);
         return pb;
     }
 
@@ -629,9 +616,7 @@ public class PViewsArea extends ProtoBase {
      */
     @PhonkMethod
     public PRadioButtonGroup addRadioButtonGroup(Object x, Object y) {
-        PRadioButtonGroup rbg = (PRadioButtonGroup) newView("radioButtonGroup");
-        addView(rbg, x, y, -1, -1);
-        return rbg;
+        return addRadioButtonGroup(x, y, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     }
 
     @PhonkMethod

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PViewsArea.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/PViewsArea.java
@@ -68,7 +68,7 @@ import io.phonk.runner.apprunner.api.widgets.PTouchPad;
 import io.phonk.runner.apprunner.api.widgets.PViewMethodsInterface;
 import io.phonk.runner.apprunner.api.widgets.PViewPager;
 import io.phonk.runner.apprunner.api.widgets.PWebView;
-import io.phonk.runner.apprunner.api.widgets.StylePropertiesProxy;
+import io.phonk.runner.apprunner.api.widgets.PropertiesProxy;
 
 @PhonkClass
 public class PViewsArea extends ProtoBase {
@@ -86,7 +86,6 @@ public class PViewsArea extends ProtoBase {
     public PToolbar toolbar;
     protected PAbsoluteLayout uiAbsoluteLayout;
     // UI
-    private StylePropertiesProxy mTheme;
     private boolean isScrollEnabled = false;
     private RelativeLayout uiHolderLayout;
     private PScrollView uiScrollView;
@@ -158,6 +157,20 @@ public class PViewsArea extends ProtoBase {
         pAbsoluteLayout.setLayoutParams(layoutParams);
 
         return pAbsoluteLayout;
+    }
+
+    public View addView(PViewMethodsInterface v) {
+        Map props = v.getProps();
+        // String type = props.get("type").toString();
+        Object x = props.get("x");
+        Object y = props.get("y");
+        Object w = props.get("w");
+        Object h = props.get("h");
+
+        // PViewMethodsInterface btn = (PViewMethodsInterface) newView(type, props);
+        this.addView((View) v, x, y, w, h);
+
+        return (View) v;
     }
 
     /**

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PCamera.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PCamera.java
@@ -31,7 +31,7 @@ import io.phonk.runner.apidoc.annotation.PhonkMethod;
 import io.phonk.runner.apidoc.annotation.PhonkMethodParam;
 import io.phonk.runner.apprunner.AppRunner;
 import io.phonk.runner.apprunner.api.common.ReturnInterface;
-import io.phonk.runner.apprunner.api.widgets.StylePropertiesProxy;
+import io.phonk.runner.apprunner.api.widgets.PropertiesProxy;
 import io.phonk.runner.apprunner.api.widgets.Styler;
 import io.phonk.runner.base.gui.CameraTexture;
 
@@ -40,7 +40,7 @@ public class PCamera extends CameraTexture implements /* PViewMethodsInterface,*
     protected final AppRunner mAppRunner;
     private final PCamera cam;
     // this is a props proxy for the user
-    public StylePropertiesProxy props = new StylePropertiesProxy();
+    public PropertiesProxy props = new PropertiesProxy();
     // the props are transformed / accessed using the styler object
     public Styler styler;
     private LearnImages learnImages = null;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PCamera.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PCamera.java
@@ -31,8 +31,6 @@ import io.phonk.runner.apidoc.annotation.PhonkMethod;
 import io.phonk.runner.apidoc.annotation.PhonkMethodParam;
 import io.phonk.runner.apprunner.AppRunner;
 import io.phonk.runner.apprunner.api.common.ReturnInterface;
-import io.phonk.runner.apprunner.api.widgets.PropertiesProxy;
-import io.phonk.runner.apprunner.api.widgets.Styler;
 import io.phonk.runner.base.gui.CameraTexture;
 
 @PhonkClass

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PCamera.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PCamera.java
@@ -36,13 +36,9 @@ import io.phonk.runner.apprunner.api.widgets.Styler;
 import io.phonk.runner.base.gui.CameraTexture;
 
 @PhonkClass
-public class PCamera extends CameraTexture implements /* PViewMethodsInterface,*/ PCameraInterface {
+public class PCamera extends CameraTexture implements PCameraInterface {
     protected final AppRunner mAppRunner;
     private final PCamera cam;
-    // this is a props proxy for the user
-    public PropertiesProxy props = new PropertiesProxy();
-    // the props are transformed / accessed using the styler object
-    public Styler styler;
     private LearnImages learnImages = null;
     private DetectImage detectImage = null;
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PVideo.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PVideo.java
@@ -38,15 +38,9 @@ import io.phonk.runner.base.gui.CustomVideoTextureView;
 import io.phonk.runner.base.utils.MLog;
 
 @PhonkClass(mergeFrom = "AudioPlayer")
-public class PVideo extends PAudioPlayer /* implements PViewMethodsInterface */ {
+public class PVideo extends PAudioPlayer {
     private static final java.lang.String TAG = PVideo.class.getSimpleName();
     private final CustomVideoTextureView mTextureView;
-
-    // this is a props proxy for the user
-    public PropertiesProxy props = new PropertiesProxy();
-
-    // the props are transformed / accessed using the styler object
-    public Styler styler;
 
     public PVideo(AppRunner appRunner) {
         super(appRunner);

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PVideo.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PVideo.java
@@ -32,7 +32,7 @@ import io.phonk.runner.apidoc.annotation.PhonkMethod;
 import io.phonk.runner.apidoc.annotation.PhonkMethodParam;
 import io.phonk.runner.apprunner.AppRunner;
 import io.phonk.runner.apprunner.api.common.ReturnObject;
-import io.phonk.runner.apprunner.api.widgets.StylePropertiesProxy;
+import io.phonk.runner.apprunner.api.widgets.PropertiesProxy;
 import io.phonk.runner.apprunner.api.widgets.Styler;
 import io.phonk.runner.base.gui.CustomVideoTextureView;
 import io.phonk.runner.base.utils.MLog;
@@ -43,7 +43,7 @@ public class PVideo extends PAudioPlayer /* implements PViewMethodsInterface */ 
     private final CustomVideoTextureView mTextureView;
 
     // this is a props proxy for the user
-    public StylePropertiesProxy props = new StylePropertiesProxy();
+    public PropertiesProxy props = new PropertiesProxy();
 
     // the props are transformed / accessed using the styler object
     public Styler styler;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PVideo.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/media/PVideo.java
@@ -32,8 +32,6 @@ import io.phonk.runner.apidoc.annotation.PhonkMethod;
 import io.phonk.runner.apidoc.annotation.PhonkMethodParam;
 import io.phonk.runner.apprunner.AppRunner;
 import io.phonk.runner.apprunner.api.common.ReturnObject;
-import io.phonk.runner.apprunner.api.widgets.PropertiesProxy;
-import io.phonk.runner.apprunner.api.widgets.Styler;
 import io.phonk.runner.base.gui.CustomVideoTextureView;
 import io.phonk.runner.base.utils.MLog;
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PAbsoluteLayout.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PAbsoluteLayout.java
@@ -184,9 +184,6 @@ public class PAbsoluteLayout extends FixedLayout {
         int mw = mAppRunner.pUtil.sizeToPixels(w, mWidth);
         int mh = mAppRunner.pUtil.sizeToPixels(h, mHeight);
 
-        if (mw < 0) mw = LayoutParams.WRAP_CONTENT;
-        if (mh < 0) mh = LayoutParams.WRAP_CONTENT;
-
         addView(v, new LayoutParams(mw, mh, mx, my));
     }
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PAbsoluteLayout.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PAbsoluteLayout.java
@@ -169,6 +169,16 @@ public class PAbsoluteLayout extends FixedLayout {
     @PhonkMethod(description = "Adds a view", example = "")
     @PhonkMethodParam(params = {"view", "x", "y", "w", "h"})
     public void addView(View v, Object x, Object y, Object w, Object h) {
+        if (v instanceof PViewMethodsInterface) {
+            PropertiesProxy map = (PropertiesProxy) ((PViewMethodsInterface) v).getProps();
+            map.eventOnChange = false;
+            map.put("x", x);
+            map.put("y", y);
+            map.put("w", w);
+            map.put("h", h);
+            map.eventOnChange = true;
+        }
+
         int mx = mAppRunner.pUtil.sizeToPixels(x, mWidth);
         int my = mAppRunner.pUtil.sizeToPixels(y, mHeight);
         int mw = mAppRunner.pUtil.sizeToPixels(w, mWidth);

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PAbsoluteLayout.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PAbsoluteLayout.java
@@ -41,9 +41,6 @@ import io.phonk.runner.base.utils.MLog;
 public class PAbsoluteLayout extends FixedLayout {
 
     private static final String TAG = PAbsoluteLayout.class.getSimpleName();
-    private static final int PIXELS = 0;
-    private static final int DP = 1;
-    private static final int NORMALIZED = 2;
     private final AppRunner mAppRunner;
     private int mWidth = -1;
     private int mHeight = -1;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PAbsoluteLayout.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PAbsoluteLayout.java
@@ -45,8 +45,8 @@ public class PAbsoluteLayout extends FixedLayout {
     private static final int DP = 1;
     private static final int NORMALIZED = 2;
     private final AppRunner mAppRunner;
-    public int mWidth = -1;
-    public int mHeight = -1;
+    private int mWidth = -1;
+    private int mHeight = -1;
 
     public PAbsoluteLayout(AppRunner appRunner) {
         super(appRunner.getAppContext());

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PButton.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PButton.java
@@ -26,6 +26,7 @@ import android.annotation.SuppressLint;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.text.Html;
+import android.text.Spanned;
 import android.view.MotionEvent;
 import android.view.View;
 
@@ -61,13 +62,14 @@ public class PButton extends androidx.appcompat.widget.AppCompatButton implement
 
         styler = new Styler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
+            apply(name, value);
         });
 
         props.eventOnChange = false;
-        props.put("textStyle", props, "bold");
-        props.put("textAlign", props, "center");
+        props.put("textStyle", "bold");
+        props.put("textAlign", "center");
         // props.put("srcTintPressed", props, appRunner.pUi.theme.get("colorSecondary"));
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
@@ -102,7 +104,7 @@ public class PButton extends androidx.appcompat.widget.AppCompatButton implement
     }
 
     public PButton text(String label) {
-        setText(label);
+        props.put("text", label);
         return this;
     }
 
@@ -159,8 +161,8 @@ public class PButton extends androidx.appcompat.widget.AppCompatButton implement
 
     @Override
     public PButton textFont(Typeface font) {
-        mFont = font;
-        this.setTypeface(font, mStyle);
+        styler.textFont = font;
+        props.put("textFont", "custom");
         MLog.d(TAG, "--> " + "font");
 
         return this;
@@ -168,52 +170,51 @@ public class PButton extends androidx.appcompat.widget.AppCompatButton implement
 
     @Override
     public View textSize(int size) {
-        setTextSize(size);
-        return this;
+        return textSize((float) size);
     }
 
     @Override
-    public PButton textColor(String c) {
-        this.setTextColor(Color.parseColor(c));
+    public PButton textColor(String textColor) {
+        props.put("textColor", textColor);
         return this;
     }
 
     @Override
     public PButton textColor(int c) {
-        this.setTextColor(c);
+        styler.textColor = c;
+        props.put("textColor", "custom");
         return this;
     }
 
     @Override
-    public View textSize(float size) {
-        this.setTextSize(size);
-
+    public View textSize(float textSize) {
+        props.put("textSize", textSize);
         return this;
     }
 
     @Override
     public View textStyle(int style) {
-        mStyle = style;
-        this.setTypeface(mFont, style);
+        styler.textStyle = style;
+        props.put("textStyle", "custom");
         return this;
     }
 
     @Override
     public View textAlign(int alignment) {
-        this.setGravity(alignment);
+        styler.textAlign = alignment;
+        props.put("textAlign", "custom");
         return this;
     }
 
     public PButton background(String c) {
-        this.setBackgroundColor(Color.parseColor(c));
+        props.put("background", c);
         return this;
     }
 
     @PhonkMethod(description = "Sets html text", example = "")
     @PhonkMethodParam(params = {"htmlText"})
     public PButton html(String htmlText) {
-        this.setText(Html.fromHtml(htmlText));
-
+        props.put("text", Html.fromHtml(htmlText));
         return this;
     }
 
@@ -252,6 +253,28 @@ public class PButton extends androidx.appcompat.widget.AppCompatButton implement
     @Override
     public Map getProps() {
         return props;
+    }
+
+    private void apply(String name, Object value) {
+        if (name == null) {
+            apply("text");
+
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "text":
+                    if (value instanceof Spanned) {
+                        setText((Spanned) value);
+                    } else {
+                        setText(value.toString());
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void apply(String name) {
+        apply(name, props.get(name));
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PButton.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PButton.java
@@ -23,7 +23,6 @@
 package io.phonk.runner.apprunner.api.widgets;
 
 import android.annotation.SuppressLint;
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.text.Html;
 import android.text.Spanned;
@@ -51,9 +50,6 @@ public class PButton extends androidx.appcompat.widget.AppCompatButton implement
     // the props are transformed / accessed using the styler object
     public final Styler styler;
 
-    private Typeface mFont;
-    private int mStyle;
-
     private ReturnInterface onPressCallback;
     private ReturnInterface onReleaseCallback;
 
@@ -68,9 +64,9 @@ public class PButton extends androidx.appcompat.widget.AppCompatButton implement
         });
 
         props.eventOnChange = false;
-        props.put("textStyle", "bold");
+        props.put("text", "");
         props.put("textAlign", "center");
-        // props.put("srcTintPressed", props, appRunner.pUi.theme.get("colorSecondary"));
+        props.put("textStyle", "bold");
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
         props.change();

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PButton.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PButton.java
@@ -45,7 +45,7 @@ public class PButton extends androidx.appcompat.widget.AppCompatButton implement
     private static final String TAG = PButton.class.getSimpleName();
 
     // this is a props proxy for the user
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
 
     // the props are transformed / accessed using the styler object
     public final Styler styler;
@@ -60,13 +60,18 @@ public class PButton extends androidx.appcompat.widget.AppCompatButton implement
         super(appRunner.getAppContext());
 
         styler = new Styler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
         props.put("textStyle", props, "bold");
         props.put("textAlign", props, "center");
         // props.put("srcTintPressed", props, appRunner.pUi.theme.get("colorSecondary"));
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -240,18 +245,13 @@ public class PButton extends androidx.appcompat.widget.AppCompatButton implement
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCanvas.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCanvas.java
@@ -46,9 +46,7 @@ import io.phonk.runner.base.utils.Image;
 
 @PhonkClass(mergeFrom = "CustomView")
 public class PCanvas {
-    private static final String TAG = PCustomView.class.getSimpleName();
     private final AppRunner mAppRunner;
-    private final boolean absoluteMode = false;
     public Canvas mCanvas;
 
     @PhonkField(description = "Canvas width", example = "")

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCheckBox.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCheckBox.java
@@ -36,7 +36,7 @@ import io.phonk.runner.apprunner.api.common.ReturnObject;
 @PhonkClass
 public class PCheckBox extends androidx.appcompat.widget.AppCompatCheckBox implements PViewMethodsInterface,
         PTextInterface {
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     public final Styler styler;
 
     private Typeface mFont;
@@ -109,18 +109,13 @@ public class PCheckBox extends androidx.appcompat.widget.AppCompatCheckBox imple
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCheckBox.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCheckBox.java
@@ -61,45 +61,46 @@ public class PCheckBox extends androidx.appcompat.widget.AppCompatCheckBox imple
 
     @Override
     public View textFont(Typeface font) {
-        mFont = font;
-        this.setTypeface(font, mStyle);
+        styler.textFont = font;
+        props.put("textFont", "custom");
         return this;
     }
 
     @Override
     public View textSize(int size) {
-        this.setTextSize(size);
-        return this;
+        return textSize((float) size);
     }
 
     @Override
     public View textColor(String textColor) {
-        this.setTextColor(Color.parseColor(textColor));
+        props.put("textColor", textColor);
         return this;
     }
 
     @Override
     public View textColor(int c) {
-        this.setTextColor(c);
+        styler.textColor = c;
+        props.put("textColor", "custom");
         return this;
     }
 
     @Override
     public View textSize(float textSize) {
-        this.setTextSize(textSize);
+        props.put("textSize", textSize);
         return this;
     }
 
     @Override
     public View textStyle(int style) {
-        mStyle = style;
-        this.setTypeface(mFont, style);
+        styler.textStyle = style;
+        props.put("textStyle", "custom");
         return this;
     }
 
     @Override
     public View textAlign(int alignment) {
-        setGravity(alignment);
+        styler.textAlign = alignment;
+        props.put("textAlign", "custom");
         return this;
     }
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCheckBox.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCheckBox.java
@@ -22,7 +22,6 @@
 
 package io.phonk.runner.apprunner.api.widgets;
 
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.view.View;
 
@@ -39,12 +38,14 @@ public class PCheckBox extends androidx.appcompat.widget.AppCompatCheckBox imple
     public final PropertiesProxy props = new PropertiesProxy();
     public final Styler styler;
 
-    private Typeface mFont;
-    private int mStyle;
-
     public PCheckBox(AppRunner appRunner) {
         super(appRunner.getAppContext());
         styler = new Styler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+        props.change();
     }
 
     public PCheckBox onChange(final ReturnInterface callbackfn) {

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCustomView.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCustomView.java
@@ -55,11 +55,10 @@ public class PCustomView extends View implements PViewMethodsInterface {
     public PCustomView(AppRunner appRunner, Map initProps) {
         super(appRunner.getAppContext());
         mAppRunner = appRunner;
-        this.setBackgroundColor(Color.TRANSPARENT);
 
         styler = new Styler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, mAppRunner);
             styler.apply(name, value);
         });
 
@@ -69,11 +68,7 @@ public class PCustomView extends View implements PViewMethodsInterface {
         props.eventOnChange = true;
         props.change();
 
-        init();
-    }
-
-    private void init() {
-        mPCanvas = new PCanvas(mAppRunner);
+        mPCanvas = new PCanvas(appRunner);
     }
 
     @Override

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCustomView.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCustomView.java
@@ -23,7 +23,6 @@
 package io.phonk.runner.apprunner.api.widgets;
 
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.view.View;
 
 import java.util.Map;
@@ -31,7 +30,6 @@ import java.util.Map;
 import io.phonk.runner.apidoc.annotation.PhonkClass;
 import io.phonk.runner.apidoc.annotation.PhonkField;
 import io.phonk.runner.apprunner.AppRunner;
-import io.phonk.runner.apprunner.api.other.PLooper;
 import io.phonk.runner.base.utils.MLog;
 
 @PhonkClass
@@ -43,14 +41,11 @@ public class PCustomView extends View implements PViewMethodsInterface {
     public final Styler styler;
     protected final AppRunner mAppRunner;
     @PhonkField(description = "Time interval between draws", example = "")
-    private final int drawInterval = 35;
     public OnSetupCallback setup;
     public OnDrawCallback draw;
-    protected boolean mAutoDraw = false;
     protected int canvasWidth;
     protected int canvasHeight;
     private PCanvas mPCanvas;
-    private PLooper loop;
 
     public PCustomView(AppRunner appRunner, Map initProps) {
         super(appRunner.getAppContext());

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCustomView.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PCustomView.java
@@ -38,7 +38,7 @@ import io.phonk.runner.base.utils.MLog;
 public class PCustomView extends View implements PViewMethodsInterface {
     private static final String TAG = PCustomView.class.getSimpleName();
     // this is a props proxy for the user
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     // the props are transformed / accessed using the styler object
     public final Styler styler;
     protected final AppRunner mAppRunner;
@@ -58,11 +58,16 @@ public class PCustomView extends View implements PViewMethodsInterface {
         this.setBackgroundColor(Color.TRANSPARENT);
 
         styler = new Styler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
         props.put("background", "#00FFFFFF");
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
 
         init();
     }
@@ -115,17 +120,12 @@ public class PCustomView extends View implements PViewMethodsInterface {
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PGrid.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PGrid.java
@@ -34,14 +34,11 @@ import io.phonk.runner.apidoc.annotation.PhonkMethodParam;
 @PhonkClass
 public class PGrid extends LinearLayout {
     private final Context context;
-    private int columns = 1;
 
     public PGrid(Context context) {
         super(context);
         this.context = context;
         setOrientation(LinearLayout.VERTICAL);
-
-
     }
 
 
@@ -58,7 +55,6 @@ public class PGrid extends LinearLayout {
     @PhonkMethod(description = "Specify the number of columns", example = "")
     @PhonkMethodParam(params = {"colums"})
     public PGrid columns(int cols) {
-        this.columns = cols;
 
         return this;
     }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImage.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImage.java
@@ -42,21 +42,22 @@ public class PImage extends androidx.appcompat.widget.AppCompatImageView impleme
     private static final String TAG = PImage.class.getSimpleName();
     public final PropertiesProxy props = new PropertiesProxy();
     protected final AppRunner mAppRunner;
-    protected final ImageStyler styler;
+    protected final Styler styler;
 
     public PImage(AppRunner appRunner, Map initProps) {
         super(appRunner.getAppContext());
         this.mAppRunner = appRunner;
 
-        styler = new ImageStyler(appRunner, this, props);
+        styler = new Styler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
+            apply(name, value);
         });
 
         props.eventOnChange = false;
-        props.put("background", props, "#00FFFFFF");
-        props.put("srcMode", props, "fit");
+        props.put("background", "#00FFFFFF");
+        props.put("srcMode", "fit");
 
         addFromChild(props);
 
@@ -100,59 +101,13 @@ public class PImage extends androidx.appcompat.widget.AppCompatImageView impleme
     }
 
     public PImage mode(String mode) {
-        switch (mode) {
-            case "tiled":
-                BitmapDrawable bitmapDrawable = ((BitmapDrawable) this.getDrawable());
-
-                Shader.TileMode tileMode = Shader.TileMode.REPEAT;
-                bitmapDrawable.setTileModeXY(tileMode, tileMode);
-
-                setBackground(bitmapDrawable);
-                setImageBitmap(null);
-                //setScaleX(2);
-                break;
-
-            case "fit":
-                this.setScaleType(ScaleType.FIT_CENTER);
-                break;
-
-            case "crop":
-                this.setScaleType(ScaleType.CENTER_CROP);
-                break;
-
-            case "resize":
-                this.setScaleType(ScaleType.FIT_XY);
-                break;
-        }
+        props.put("srcMode", mode);
         return this;
     }
 
     @Override
     public void set(float x, float y, float w, float h) {
         styler.setLayoutProps(x, y, w, h);
-    }
-
-    class ImageStyler extends Styler {
-        ImageStyler(AppRunner appRunner, View view, PropertiesProxy props) {
-            super(appRunner, view, props);
-        }
-
-        @Override
-        public void apply(String name, Object value) {
-            super.apply(name, value);
-
-            if (name == null) {
-                apply("srcMode");
-
-            } else {
-                if (value == null) return;
-                switch (name) {
-                    case "srcMode":
-                        mode(value.toString());
-                        break;
-                }
-            }
-        }
     }
 
     @Override
@@ -163,6 +118,46 @@ public class PImage extends androidx.appcompat.widget.AppCompatImageView impleme
     @Override
     public Map getProps() {
         return props;
+    }
+
+    private void apply(String name, Object value) {
+        if (name == null) {
+            apply("srcMode");
+
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "srcMode":
+                    switch (value.toString()) {
+                        case "tiled":
+                            BitmapDrawable bitmapDrawable = ((BitmapDrawable) this.getDrawable());
+
+                            Shader.TileMode tileMode = Shader.TileMode.REPEAT;
+                            bitmapDrawable.setTileModeXY(tileMode, tileMode);
+
+                            setBackground(bitmapDrawable);
+                            setImageBitmap(null);
+                            break;
+
+                        case "fit":
+                            this.setScaleType(ScaleType.FIT_CENTER);
+                            break;
+
+                        case "crop":
+                            this.setScaleType(ScaleType.CENTER_CROP);
+                            break;
+
+                        case "resize":
+                            this.setScaleType(ScaleType.FIT_XY);
+                            break;
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void apply(String name) {
+        apply(name, props.get(name));
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImage.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImage.java
@@ -25,7 +25,6 @@ package io.phonk.runner.apprunner.api.widgets;
 import android.graphics.Bitmap;
 import android.graphics.Shader;
 import android.graphics.drawable.BitmapDrawable;
-import android.view.View;
 
 import com.squareup.picasso.Picasso;
 
@@ -39,7 +38,6 @@ import io.phonk.runner.apprunner.AppRunner;
 
 @PhonkClass
 public class PImage extends androidx.appcompat.widget.AppCompatImageView implements PViewMethodsInterface {
-    private static final String TAG = PImage.class.getSimpleName();
     public final PropertiesProxy props = new PropertiesProxy();
     protected final AppRunner mAppRunner;
     protected final Styler styler;
@@ -131,24 +129,21 @@ public class PImage extends androidx.appcompat.widget.AppCompatImageView impleme
                     switch (value.toString()) {
                         case "tiled":
                             BitmapDrawable bitmapDrawable = ((BitmapDrawable) this.getDrawable());
-
-                            Shader.TileMode tileMode = Shader.TileMode.REPEAT;
-                            bitmapDrawable.setTileModeXY(tileMode, tileMode);
-
+                            bitmapDrawable.setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT);
                             setBackground(bitmapDrawable);
                             setImageBitmap(null);
                             break;
 
                         case "fit":
-                            this.setScaleType(ScaleType.FIT_CENTER);
+                            setScaleType(ScaleType.FIT_CENTER);
                             break;
 
                         case "crop":
-                            this.setScaleType(ScaleType.CENTER_CROP);
+                            setScaleType(ScaleType.CENTER_CROP);
                             break;
 
                         case "resize":
-                            this.setScaleType(ScaleType.FIT_XY);
+                            setScaleType(ScaleType.FIT_XY);
                             break;
                     }
                     break;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImage.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImage.java
@@ -40,7 +40,7 @@ import io.phonk.runner.apprunner.AppRunner;
 @PhonkClass
 public class PImage extends androidx.appcompat.widget.AppCompatImageView implements PViewMethodsInterface {
     private static final String TAG = PImage.class.getSimpleName();
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     protected final AppRunner mAppRunner;
     protected final ImageStyler styler;
 
@@ -49,18 +49,23 @@ public class PImage extends androidx.appcompat.widget.AppCompatImageView impleme
         this.mAppRunner = appRunner;
 
         styler = new ImageStyler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
         props.put("background", props, "#00FFFFFF");
         props.put("srcMode", props, "fit");
 
         addFromChild(props);
 
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
     }
 
-    protected void addFromChild(StylePropertiesProxy props) {
+    protected void addFromChild(PropertiesProxy props) {
     }
 
     @PhonkMethod(description = "Sets an image", example = "")
@@ -128,31 +133,36 @@ public class PImage extends androidx.appcompat.widget.AppCompatImageView impleme
     }
 
     class ImageStyler extends Styler {
-        ImageStyler(AppRunner appRunner, View view, StylePropertiesProxy props) {
+        ImageStyler(AppRunner appRunner, View view, PropertiesProxy props) {
             super(appRunner, view, props);
         }
 
         @Override
-        public void apply() {
-            super.apply();
+        public void apply(String name, Object value) {
+            super.apply(name, value);
 
-            mode(mProps.get("srcMode").toString());
+            if (name == null) {
+                apply("srcMode");
+
+            } else {
+                if (value == null) return;
+                switch (name) {
+                    case "srcMode":
+                        mode(value.toString());
+                        break;
+                }
+            }
         }
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImageButton.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImageButton.java
@@ -49,9 +49,8 @@ public class PImageButton extends PImage {
     @Override
     protected void addFromChild(PropertiesProxy props) {
         super.addFromChild(props);
-        props.put("background", props, mAppRunner.pUi.theme.get("primaryShade"));
-        // props.put("srcTintPressed", props, mAppRunner.pUi.theme.get("secondary"));
-        props.put("padding", props, mAppRunner.pUtil.dpToPixels(10));
+        props.put("background", mAppRunner.pUi.theme.get("primaryShade"));
+        props.put("padding", mAppRunner.pUtil.dpToPixels(10));
     }
 
     // Set on click behavior

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImageButton.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImageButton.java
@@ -37,7 +37,6 @@ import io.phonk.runner.base.utils.MLog;
 public class PImageButton extends PImage {
     private final String TAG = PImageButton.class.getSimpleName();
 
-    private final boolean hideBackground = true;
     private Bitmap mBitmap;
     private Bitmap mBitmapPressed;
     private ReturnInterface callbackfn;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImageButton.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PImageButton.java
@@ -47,7 +47,7 @@ public class PImageButton extends PImage {
     }
 
     @Override
-    protected void addFromChild(StylePropertiesProxy props) {
+    protected void addFromChild(PropertiesProxy props) {
         super.addFromChild(props);
         props.put("background", props, mAppRunner.pUi.theme.get("primaryShade"));
         // props.put("srcTintPressed", props, mAppRunner.pUi.theme.get("secondary"));

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PInput.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PInput.java
@@ -49,8 +49,6 @@ public class PInput extends androidx.appcompat.widget.AppCompatEditText implemen
     public final Styler styler;
     private final AppRunner mAppRunner;
     private final EditText mInput;
-    private Typeface mFont;
-    private int mStyle;
 
     public PInput(AppRunner appRunner, Map initProps) {
         super(appRunner.getAppContext());
@@ -229,9 +227,9 @@ public class PInput extends androidx.appcompat.widget.AppCompatEditText implemen
 
                 case "multiline":
                     if (value instanceof Boolean && (Boolean) value) {
-                        this.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
-                        this.setSingleLine(false);
-                        this.setGravity(Gravity.TOP);
+                        setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+                        setSingleLine(false);
+                        setGravity(Gravity.TOP);
                     }
                     break;
             }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PInput.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PInput.java
@@ -45,7 +45,7 @@ import io.phonk.runner.apprunner.api.common.ReturnObject;
 @PhonkClass
 public class PInput extends androidx.appcompat.widget.AppCompatEditText implements PViewMethodsInterface,
         PTextInterface {
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     public final InputStyler styler;
     private final AppRunner mAppRunner;
     private final EditText mInput;
@@ -60,6 +60,11 @@ public class PInput extends androidx.appcompat.widget.AppCompatEditText implemen
         setFocusableInTouchMode(true);
 
         styler = new InputStyler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
         props.put("textAlign", props, "left");
         props.put("background", props, "#00FFFFFF"); // appRunner.pUi.theme.get("secondaryShade"));
@@ -71,9 +76,9 @@ public class PInput extends androidx.appcompat.widget.AppCompatEditText implemen
         props.put("paddingRight", props, appRunner.pUtil.dpToPixels(10));
         props.put("textColor", props, appRunner.pUi.theme.get("textPrimary"));
         props.put("hintColor", props, appRunner.pUi.theme.get("secondaryShade"));
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
 
         mInput = this;
     }
@@ -129,7 +134,7 @@ public class PInput extends androidx.appcompat.widget.AppCompatEditText implemen
         return this;
     }
 
-    public View text(String txt) {
+    public PInput text(String txt) {
         this.setText(txt);
         return this;
     }
@@ -194,8 +199,8 @@ public class PInput extends androidx.appcompat.widget.AppCompatEditText implemen
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     private void hideKeyboard(View view) {
@@ -210,21 +215,26 @@ public class PInput extends androidx.appcompat.widget.AppCompatEditText implemen
     }
 
     class InputStyler extends Styler {
-        InputStyler(AppRunner appRunner, View view, StylePropertiesProxy props) {
+        InputStyler(AppRunner appRunner, View view, PropertiesProxy props) {
             super(appRunner, view, props);
         }
 
         @Override
-        public void apply() {
-            super.apply();
+        public void apply(String name, Object value) {
+            super.apply(name, value);
 
-            setHintTextColor(Color.parseColor(mProps.get("hintColor").toString()));
+            if (name == null) {
+                apply("hintColor");
+
+            } else {
+                if (value == null) return;
+                switch (name) {
+                    case "hintColor":
+                        setHintTextColor(Color.parseColor(value.toString()));
+                        break;
+                }
+            }
         }
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PKnob.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PKnob.java
@@ -42,7 +42,7 @@ import io.phonk.runner.base.views.CanvasUtils;
 public class PKnob extends PCustomView implements PViewMethodsInterface, PTextInterface {
     private static final String TAG = PKnob.class.getSimpleName();
 
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     public final KnobStyler styler;
     private final boolean autoTextSize = false;
     private final DecimalFormat df;
@@ -104,6 +104,11 @@ public class PKnob extends PCustomView implements PViewMethodsInterface, PTextIn
         draw = mydraw;
 
         styler = new KnobStyler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
         props.put("knobBorderWidth", props, appRunner.pUtil.dpToPixels(1));
         props.put("knobProgressWidth", props, appRunner.pUtil.dpToPixels(2));
@@ -115,9 +120,9 @@ public class PKnob extends PCustomView implements PViewMethodsInterface, PTextIn
         props.put("textColor", props, appRunner.pUi.theme.get("secondary"));
         props.put("textFont", props, "monospace");
         props.put("textSize", props, appRunner.pUtil.dpToPixels(4));
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
 
         df = new DecimalFormat("#.##");
         decimals(2);
@@ -220,8 +225,8 @@ public class PKnob extends PCustomView implements PViewMethodsInterface, PTextIn
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
@@ -266,25 +271,46 @@ public class PKnob extends PCustomView implements PViewMethodsInterface, PTextIn
         int knobBorderColor;
         int knobProgressColor;
 
-        KnobStyler(AppRunner appRunner, View view, StylePropertiesProxy props) {
+        KnobStyler(AppRunner appRunner, View view, PropertiesProxy props) {
             super(appRunner, view, props);
         }
 
         @Override
-        public void apply() {
-            super.apply();
+        public void apply(String name, Object value) {
+            super.apply(name, value);
 
-            knobProgressSeparation = toFloat(mProps.get("knobProgressSeparation"));
-            knobBorderWidth = toFloat(mProps.get("knobBorderWidth"));
-            knobProgressWidth = toFloat(mProps.get("knobProgressWidth"));
-            knobBorderColor = Color.parseColor(mProps.get("knobBorderColor").toString());
-            knobProgressColor = Color.parseColor(mProps.get("knobProgressColor").toString());
+            if (name == null) {
+                apply("knobProgressSeparation");
+                apply("knobBorderWidth");
+                apply("knobProgressWidth");
+                apply("knobBorderColor");
+                apply("knobProgressColor");
+
+            } else {
+                if (value == null) return;
+                switch (name) {
+                    case "knobProgressSeparation":
+                        knobProgressSeparation = toFloat(value);
+                        break;
+
+                    case "knobBorderWidth":
+                        knobBorderWidth = toFloat(value);
+                        break;
+
+                    case "knobProgressWidth":
+                        knobProgressWidth = toFloat(value);
+                        break;
+
+                    case "knobBorderColor":
+                        knobBorderColor = Color.parseColor(value.toString());
+                        break;
+
+                    case "knobProgressColor":
+                        knobProgressColor = Color.parseColor(value.toString());
+                        break;
+                }
+            }
         }
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PKnob.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PKnob.java
@@ -23,9 +23,7 @@
 package io.phonk.runner.apprunner.api.widgets;
 
 import android.graphics.Color;
-import android.graphics.Typeface;
 import android.view.MotionEvent;
-import android.view.View;
 
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
@@ -40,16 +38,14 @@ import io.phonk.runner.base.views.CanvasUtils;
 
 @PhonkClass
 public class PKnob extends PCustomView {
-    private static final String TAG = PKnob.class.getSimpleName();
 
-    private final boolean autoTextSize = false;
+    private boolean autoTextSize;
     private final DecimalFormat df = new DecimalFormat("#.##");
     private ReturnInterface callbackDrag;
     private ReturnInterface callbackRelease;
     private float firstY;
     private float prevVal = 0;
     private float val = 0;
-    private int mWidth;
     private int mHeight;
     private float mappedVal;
     private float unmappedVal;
@@ -63,7 +59,6 @@ public class PKnob extends PCustomView {
     final OnDrawCallback mydraw = new OnDrawCallback() {
         @Override
         public void event(PCanvas c) {
-            mWidth = c.width;
             mHeight = c.height;
 
             c.clear();
@@ -104,7 +99,7 @@ public class PKnob extends PCustomView {
     private float rangeTo;
 
     public PKnob(AppRunner appRunner, Map initProps) {
-        super(appRunner, initProps);
+        super(appRunner, null);
 
         draw = mydraw;
 
@@ -120,6 +115,7 @@ public class PKnob extends PCustomView {
         props.put("knobProgressSeparation", appRunner.pUtil.dpToPixels(15));
         props.put("knobBorderColor", appRunner.pUi.theme.get("secondaryShade"));
         props.put("knobProgressColor", appRunner.pUi.theme.get("primary"));
+        props.put("autoTextSize", false);
         props.put("decimals", 2);
         props.put("from", 0);
         props.put("to", 360);
@@ -216,6 +212,7 @@ public class PKnob extends PCustomView {
             apply("knobProgressWidth");
             apply("knobBorderColor");
             apply("knobProgressColor");
+            apply("autoTextSize");
             apply("decimals");
             apply("from");
             apply("to");
@@ -244,6 +241,12 @@ public class PKnob extends PCustomView {
                     progressColor = Color.parseColor(value.toString());
                     break;
 
+                case "autoTextSize":
+                    if (value instanceof Boolean) {
+                        autoTextSize = (Boolean) value;
+                    }
+                    break;
+
                 case "decimals":
                     if (value instanceof Number) {
                         int num = ((Number) value).intValue();
@@ -270,9 +273,8 @@ public class PKnob extends PCustomView {
 
                 case "value":
                     if (value instanceof Number) {
-                        float val = ((Number) value).floatValue();
-                        mappedVal = val;
-                        unmappedVal = CanvasUtils.map(val, rangeFrom, rangeTo, 0, 360);
+                        mappedVal = ((Number) value).floatValue();
+                        unmappedVal = CanvasUtils.map(mappedVal, rangeFrom, rangeTo, 0, 360);
                         invalidate();
                     }
                     break;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PLinearLayout.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PLinearLayout.java
@@ -63,34 +63,50 @@ public class PLinearLayout extends LinearLayout {
         setLayoutParams(mLp);
     }
 
-    public void orientation(String orientation) {
-        int mode = VERTICAL;
-        if ("horizontal".equals(orientation)) {
-            mode = HORIZONTAL;
-        }
-        setOrientation(mode);
-
+    public PLinearLayout orientation(String orientation) {
+        setOrientation("horizontal".equals(orientation) ? HORIZONTAL : VERTICAL);
+        return this;
     }
 
     @PhonkMethod(description = "", example = "")
     @PhonkMethodParam(params = {""})
-    public void add(View v, String name) {
+    public PLinearLayout add(View v, String name) {
         addView(v);
         mViews.put(name, v);
+        return this;
     }
 
-    public void add(View v, String name, float weight) {
-        add(v, name, LayoutParams.WRAP_CONTENT, weight);
+    public PLinearLayout add(View v, String name, float weight) {
+        return add(v, name, LayoutParams.WRAP_CONTENT, weight);
     }
 
-    public void add(View v, String name, float height, float weight) {
+    public PLinearLayout add(View v, String name, Object height, float weight) {
+        return add(v, name, LayoutParams.WRAP_CONTENT, height, weight);
+    }
+
+    public PLinearLayout add(View v, String name, Object width, Object height, float weight) {
+        if (v instanceof PViewMethodsInterface) {
+            PropertiesProxy props = (PropertiesProxy) ((PViewMethodsInterface) v).getProps();
+            props.eventOnChange = false;
+            props.put("w", width);
+            props.put("h", height);
+            props.eventOnChange = true;
+        }
+
+        int w = mAppRunner.pUtil.sizeToPixels(width, mAppRunner.pUi.screenWidth);
+        int h = mAppRunner.pUtil.sizeToPixels(height, mAppRunner.pUi.screenHeight);
+
+        if (w < 0) w = LayoutParams.WRAP_CONTENT;
+        if (h < 0) h = LayoutParams.WRAP_CONTENT;
+
         // lp.gravity = Gravity.CENTER;
-        LinearLayout.LayoutParams lp = new LayoutParams(0, (int) height, weight);
+        LinearLayout.LayoutParams lp = new LayoutParams(w, h, weight);
 
         mViews.put(name, v);
 
         // setWeightSum(1.0f);
         addView(v, lp);
+        return this;
     }
 
     public View get(String name) {

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PLinearLayout.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PLinearLayout.java
@@ -34,7 +34,7 @@ import io.phonk.runner.apidoc.annotation.PhonkMethod;
 import io.phonk.runner.apidoc.annotation.PhonkMethodParam;
 import io.phonk.runner.apprunner.AppRunner;
 
-public class PLinearLayout extends LinearLayout {
+public class PLinearLayout extends LinearLayout implements PViewMethodsInterface {
 
     public final PropertiesProxy props = new PropertiesProxy();
     public final Styler styler;
@@ -75,9 +75,7 @@ public class PLinearLayout extends LinearLayout {
     @PhonkMethod(description = "", example = "")
     @PhonkMethodParam(params = {""})
     public PLinearLayout add(View v, String name) {
-        addView(v);
-        mViews.put(name, v);
-        return this;
+        return add(v, name, 0);
     }
 
     public PLinearLayout add(View v, String name, float weight) {
@@ -186,6 +184,21 @@ public class PLinearLayout extends LinearLayout {
 
     private void apply(String name) {
         apply(name, props.get(name));
+    }
+
+    @Override
+    public void set(float x, float y, float w, float h) {
+        styler.setLayoutProps(x, y, w, h);
+    }
+
+    @Override
+    public Map getProps() {
+        return props;
+    }
+
+    @Override
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PLinearLayout.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PLinearLayout.java
@@ -36,7 +36,7 @@ import io.phonk.runner.apprunner.AppRunner;
 
 public class PLinearLayout extends LinearLayout {
 
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     public final Styler styler;
     private final AppRunner mAppRunner;
     private final LayoutParams mLp;
@@ -47,8 +47,15 @@ public class PLinearLayout extends LinearLayout {
         mAppRunner = appRunner;
 
         styler = new Styler(appRunner, this, props);
-        Styler.fromTo(initProps, props);
-        styler.apply();
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
+        props.eventOnChange = false;
+        WidgetHelper.fromTo(initProps, props);
+        props.eventOnChange = true;
+        props.change();
 
         mLp = new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, 1f);
         orientation("vertical");

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PLinearLayout.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PLinearLayout.java
@@ -22,7 +22,6 @@
 
 package io.phonk.runner.apprunner.api.widgets;
 
-import android.graphics.Color;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -42,8 +41,8 @@ public class PLinearLayout extends LinearLayout implements PViewMethodsInterface
     private final LayoutParams mLp;
     private final HashMap<String, View> mViews = new HashMap<>();
 
-    private int horizontalAlign = Gravity.LEFT;
-    private int verticalAlign = Gravity.TOP;
+    private int horizontalAlign;
+    private int verticalAlign;
 
     public PLinearLayout(AppRunner appRunner, Map initProps) {
         super(appRunner.getAppContext());
@@ -58,6 +57,8 @@ public class PLinearLayout extends LinearLayout implements PViewMethodsInterface
 
         props.eventOnChange = false;
         props.put("orientation", "vertical");
+        props.put("horizontalAlign", "left");
+        props.put("verticalAlign", "top");
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
         props.change();
@@ -118,11 +119,9 @@ public class PLinearLayout extends LinearLayout implements PViewMethodsInterface
     }
 
     public void padding(float l, float t, float r, float b) {
-        props.eventOnChange = false;
         props.put("paddingLeft", l);
         props.put("paddingTop", t);
         props.put("paddingRight", r);
-        props.eventOnChange = true;
         props.put("paddingBottom", b);
     }
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PList.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PList.java
@@ -45,6 +45,7 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
     private GridLayoutManager mGridLayoutManager;
     private PViewItemAdapter mViewAdapter;
     private int nNumCols;
+    private boolean stackFromEnd;
 
     public PList(AppRunner appRunner, Map initProps) {
         super(appRunner.getAppContext());
@@ -55,19 +56,15 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
         props.onChange((name, value) -> {
             WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
+            apply(name, value);
         });
 
         props.eventOnChange = false;
         props.put("columns", 1);
         props.put("stackFromEnd", false);
-        addFromChild(props);
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
         props.change();
-    }
-
-
-    protected void addFromChild(PropertiesProxy props) {
     }
 
     public void init(
@@ -76,6 +73,7 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
             ReturnInterfaceWithReturn bindingCallback
     ) {
         mGridLayoutManager = new GridLayoutManager(mContext, nNumCols);
+        mGridLayoutManager.setStackFromEnd(stackFromEnd);
         setLayoutManager(mGridLayoutManager);
         mViewAdapter = new PViewItemAdapter(mContext, data, createCallback, bindingCallback);
 
@@ -146,7 +144,8 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
 
                 case "stackFromEnd":
                     if (value instanceof Boolean) {
-                        mGridLayoutManager.setStackFromEnd((Boolean) value);
+                        stackFromEnd = (Boolean) value;
+                        if (mGridLayoutManager != null) mGridLayoutManager.setStackFromEnd(stackFromEnd);
                     }
                     break;
             }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PList.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PList.java
@@ -53,7 +53,7 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
 
         styler = new Styler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
         });
 
@@ -94,17 +94,11 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
     }
 
     public void stackFromEnd(boolean b) {
-        mGridLayoutManager.setStackFromEnd(b);
-    }
-
-    public void scrollToPosition(int pos) {
-        super.scrollToPosition(pos);
+        props.put("stackFromEnd", b);
     }
 
     public PList numColumns(int num) {
-        nNumCols = num;
-        if (mGridLayoutManager != null) mGridLayoutManager.setSpanCount(num);
-
+        props.put("columns", num);
         return this;
     }
 
@@ -132,5 +126,33 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
     @Override
     public Map getProps() {
         return props;
+    }
+
+    private void apply(String name, Object value) {
+        if (name == null) {
+            apply("columns");
+            apply("stackFromEnd");
+
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "columns":
+                    if (value instanceof Number) {
+                        nNumCols = ((Number) value).intValue();
+                        if (mGridLayoutManager != null) mGridLayoutManager.setSpanCount(nNumCols);
+                    }
+                    break;
+
+                case "stackFromEnd":
+                    if (value instanceof Boolean) {
+                        mGridLayoutManager.setStackFromEnd((Boolean) value);
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void apply(String name) {
+        apply(name, props.get(name));
     }
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PList.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PList.java
@@ -23,7 +23,6 @@
 package io.phonk.runner.apprunner.api.widgets;
 
 import android.content.Context;
-import android.view.View;
 
 import androidx.recyclerview.widget.GridLayoutManager;
 
@@ -39,7 +38,7 @@ import io.phonk.runner.base.views.FitRecyclerView;
 
 public class PList extends FitRecyclerView implements PViewMethodsInterface {
 
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     public final Styler styler;
     protected final AppRunner mAppRunner;
     private final Context mContext;
@@ -53,16 +52,21 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
         mContext = appRunner.getAppContext();
 
         styler = new Styler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
 
         addFromChild(props);
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
     }
 
 
-    protected void addFromChild(StylePropertiesProxy props) {
+    protected void addFromChild(PropertiesProxy props) {
     }
 
     public void init(
@@ -121,17 +125,12 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PList.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PList.java
@@ -44,7 +44,7 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
     private final Context mContext;
     private GridLayoutManager mGridLayoutManager;
     private PViewItemAdapter mViewAdapter;
-    private int nNumCols = 1;
+    private int nNumCols;
 
     public PList(AppRunner appRunner, Map initProps) {
         super(appRunner.getAppContext());
@@ -58,7 +58,8 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
         });
 
         props.eventOnChange = false;
-
+        props.put("columns", 1);
+        props.put("stackFromEnd", false);
         addFromChild(props);
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
@@ -128,7 +129,7 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
         return props;
     }
 
-    private void apply(String name, Object value) {
+    protected void apply(String name, Object value) {
         if (name == null) {
             apply("columns");
             apply("stackFromEnd");
@@ -152,7 +153,7 @@ public class PList extends FitRecyclerView implements PViewMethodsInterface {
         }
     }
 
-    private void apply(String name) {
+    protected void apply(String name) {
         apply(name, props.get(name));
     }
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PListItem.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PListItem.java
@@ -37,13 +37,10 @@ import io.phonk.runner.apidoc.annotation.PhonkMethodParam;
 public class PListItem extends LinearLayout {
 
     private final WeakReference<View> v;
-    // private Context c;
-    private final Context c;
     private String t;
 
     public PListItem(Context context) {
         super(context);
-        this.c = context;
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
         //TODO activate this
@@ -71,7 +68,7 @@ public class PListItem extends LinearLayout {
         //TODO activate this
         TextView textView = null; //(TextView) v.get().findViewById(R.id.customViewText);
         // TextUtils.changeFont(c.get(), textView, ProtocoderFonts.MENU_TITLE);
-        textView.setText(text);
+        // textView.setText(text);
     }
 
     //TODO place holder

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMap.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMap.java
@@ -68,12 +68,11 @@ public class PMap extends MapView implements PViewMethodsInterface {
     final String TAG = PMap.class.getSimpleName();
     // MyLocationNewOverlay myLocationOverlay;
     final ItemizedOverlayWithFocus<OverlayItem> iconOverlay;
-    private final boolean firstMarker = false;
     private final AppRunner mAppRunner;
     private final Context mContext;
-    private IMapController mapController = null;
-    private MapView mapView = null;
-    private ArrayList<OverlayItem> markerList = null;
+    private IMapController mapController;
+    private MapView mapView;
+    private ArrayList<OverlayItem> markerList;
 
     public PMap(AppRunner appRunner, Map initProps) {
         super(appRunner.getAppContext());

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMap.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMap.java
@@ -83,7 +83,7 @@ public class PMap extends MapView implements PViewMethodsInterface {
 
         styler = new Styler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
         });
 
@@ -294,8 +294,7 @@ public class PMap extends MapView implements PViewMethodsInterface {
      */
     @PhonkMethod
     public MapView zoom(int zoom) {
-        mapController.setZoom(zoom);
-
+        props.put("zoom", zoom);
         return this;
     }
 
@@ -307,8 +306,7 @@ public class PMap extends MapView implements PViewMethodsInterface {
      */
     @PhonkMethod
     public MapView showControls(boolean b) {
-        mapView.setBuiltInZoomControls(b);
-
+        props.put("controls", b);
         return this;
     }
 
@@ -320,7 +318,7 @@ public class PMap extends MapView implements PViewMethodsInterface {
      */
     @PhonkMethod
     public MapView multitouch(boolean b) {
-        mapView.setMultiTouchControls(b);
+        props.put("multitouch", b);
         return this;
     }
 
@@ -386,9 +384,8 @@ public class PMap extends MapView implements PViewMethodsInterface {
      */
     @PhonkMethod
     public MapView zoomLimits(double min, double max) {
-        mapView.setMinZoomLevel(min);
-        mapView.setMaxZoomLevel(max);
-
+        props.put("minZoom", min);
+        props.put("maxZoom", max);
         return this;
     }
 
@@ -424,7 +421,7 @@ public class PMap extends MapView implements PViewMethodsInterface {
      * @param b
      */
     public void useOnlineData(boolean b) {
-        mapView.setUseDataConnection(b);
+        props.put("online", b);
     }
 
     /*
@@ -521,6 +518,61 @@ public class PMap extends MapView implements PViewMethodsInterface {
     @Override
     public Map getProps() {
         return props;
+    }
+
+    private void apply(String name, Object value) {
+        if (name == null) {
+            apply("controls");
+            apply("maxZoom");
+            apply("minZoom");
+            apply("multitouch");
+            apply("online");
+            apply("zoom");
+
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "controls":
+                    if (value instanceof Boolean) {
+                        mapView.setBuiltInZoomControls((Boolean) value);
+                    }
+                    break;
+
+                case "maxZoom":
+                    if (value instanceof Number) {
+                        mapView.setMaxZoomLevel(((Number) value).doubleValue());
+                    }
+                    break;
+
+                case "minZoom":
+                    if (value instanceof Number) {
+                        mapView.setMinZoomLevel(((Number) value).doubleValue());
+                    }
+                    break;
+
+                case "multitouch":
+                    if (value instanceof Boolean) {
+                        mapView.setMultiTouchControls((Boolean) value);
+                    }
+                    break;
+
+                case "online":
+                    if (value instanceof Boolean) {
+                        mapView.setUseDataConnection((Boolean) value);
+                    }
+                    break;
+
+                case "zoom":
+                    if (value instanceof Number) {
+                        mapController.setZoom(((Number) value).intValue());
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void apply(String name) {
+        apply(name, props.get(name));
     }
 }
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMap.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMap.java
@@ -62,7 +62,7 @@ import io.phonk.runner.base.utils.MLog;
 @PhonkClass
 public class PMap extends MapView implements PViewMethodsInterface {
     // this is a props proxy for the user
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     // the props are transformed / accessed using the styler object
     public final Styler styler;
     final String TAG = PMap.class.getSimpleName();
@@ -82,10 +82,15 @@ public class PMap extends MapView implements PViewMethodsInterface {
         this.mContext = appRunner.getAppContext();
 
         styler = new Styler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
 
         Configuration.getInstance().setUserAgentValue(this.mContext.getApplicationContext().getPackageName());
 
@@ -509,18 +514,13 @@ public class PMap extends MapView implements PViewMethodsInterface {
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 }
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMatrix.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMatrix.java
@@ -40,7 +40,7 @@ public class PMatrix extends PCustomView implements PViewMethodsInterface {
     private static final String TAG = PMatrix.class.getSimpleName();
     private static final int STATUS_DISABLED = 0;
     private static final int STATUS_ENABLED = 1;
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     public final MatrixStyler styler;
     private final int colorUnselected;
     int COLS = 20;
@@ -107,6 +107,11 @@ public class PMatrix extends PCustomView implements PViewMethodsInterface {
         draw = mydraw;
 
         styler = new MatrixStyler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
         props.put("matrixCellColor", props, "#00FFFFFF");
         props.put("matrixCellSelectedColor", props, appRunner.pUi.theme.get("primary"));
@@ -119,9 +124,9 @@ public class PMatrix extends PCustomView implements PViewMethodsInterface {
         props.put("matrixCellBorderRadius", props, 0);
         props.put("background", props, "#00FFFFFF");
         props.put("backgroundPressed", props, "#00FFFFFF");
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
 
         colorUnselected = styler.matrixCellColor;
         colorSelected = styler.matrixCellSelectedColor;
@@ -285,34 +290,51 @@ public class PMatrix extends PCustomView implements PViewMethodsInterface {
         float matrixCellBorderSize;
         int matrixCellBorderColor;
 
-        MatrixStyler(AppRunner appRunner, View view, StylePropertiesProxy props) {
+        MatrixStyler(AppRunner appRunner, View view, PropertiesProxy props) {
             super(appRunner, view, props);
         }
 
         @Override
-        public void apply() {
-            super.apply();
+        public void apply(String name, Object value) {
+            super.apply(name, value);
 
-            matrixCellColor = Color.parseColor(mProps.get("matrixCellColor").toString());
-            matrixCellSelectedColor = Color.parseColor(mProps.get("matrixCellSelectedColor").toString());
-            matrixCellBorderSize = toFloat(mProps.get("matrixCellBorderSize"));
-            matrixCellBorderColor = Color.parseColor(mProps.get("matrixCellBorderColor").toString());
+            if (name == null) {
+                apply("matrixCellColor");
+                apply("matrixCellSelectedColor");
+                apply("matrixCellBorderSize");
+                apply("matrixCellBorderColor");
+
+            } else {
+                if (value == null) return;
+                switch (name) {
+                    case "matrixCellColor":
+                        matrixCellColor = Color.parseColor(value.toString());
+                        break;
+
+                    case "matrixCellSelectedColor":
+                        matrixCellSelectedColor = Color.parseColor(value.toString());
+                        break;
+
+                    case "matrixCellBorderSize":
+                        matrixCellBorderSize = toFloat(value);
+                        break;
+
+                    case "matrixCellBorderColor":
+                        matrixCellBorderColor = Color.parseColor(value.toString());
+                        break;
+                }
+            }
         }
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMatrix.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMatrix.java
@@ -36,19 +36,13 @@ import io.phonk.runner.apprunner.api.common.ReturnObject;
 import io.phonk.runner.base.utils.MLog;
 
 @PhonkClass
-public class PMatrix extends PCustomView implements PViewMethodsInterface {
+public class PMatrix extends PCustomView {
     private static final String TAG = PMatrix.class.getSimpleName();
-    private static final int STATUS_DISABLED = 0;
-    private static final int STATUS_ENABLED = 1;
-    public final PropertiesProxy props = new PropertiesProxy();
     public final MatrixStyler styler;
     private final int colorUnselected;
     int COLS = 20;
     int ROWS = 20;
     boolean wasSelected = false;
-    private ArrayList touches;
-    private float x;
-    private float y;
     private int[][] matrix;
     private int colorSelected;
     private float W;
@@ -108,22 +102,22 @@ public class PMatrix extends PCustomView implements PViewMethodsInterface {
 
         styler = new MatrixStyler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
         });
 
         props.eventOnChange = false;
-        props.put("matrixCellColor", props, "#00FFFFFF");
-        props.put("matrixCellSelectedColor", props, appRunner.pUi.theme.get("primary"));
+        props.put("matrixCellColor", "#00FFFFFF");
+        props.put("matrixCellSelectedColor", appRunner.pUi.theme.get("primary"));
 
-        props.put("borderColor", props, appRunner.pUi.theme.get("secondaryShade"));
-        props.put("borderRadius", props, 0);
+        props.put("borderColor", appRunner.pUi.theme.get("secondaryShade"));
+        props.put("borderRadius", 0);
 
-        props.put("matrixCellBorderSize", props, appRunner.pUtil.dpToPixels(1));
-        props.put("matrixCellBorderColor", props, appRunner.pUi.theme.get("secondaryShade"));
-        props.put("matrixCellBorderRadius", props, 0);
-        props.put("background", props, "#00FFFFFF");
-        props.put("backgroundPressed", props, "#00FFFFFF");
+        props.put("matrixCellBorderSize", appRunner.pUtil.dpToPixels(1));
+        props.put("matrixCellBorderColor", appRunner.pUi.theme.get("secondaryShade"));
+        props.put("matrixCellBorderRadius", 0);
+        props.put("background", "#00FFFFFF");
+        props.put("backgroundPressed", "#00FFFFFF");
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
         props.change();
@@ -279,11 +273,6 @@ public class PMatrix extends PCustomView implements PViewMethodsInterface {
         return this;
     }
 
-    @Override
-    public void set(float x, float y, float w, float h) {
-        styler.setLayoutProps(x, y, w, h);
-    }
-
     static class MatrixStyler extends Styler {
         int matrixCellColor;
         int matrixCellSelectedColor;
@@ -327,15 +316,6 @@ public class PMatrix extends PCustomView implements PViewMethodsInterface {
         }
     }
 
-    @Override
-    public void setProps(Map props) {
-        WidgetHelper.setProps(this.props, props);
-    }
-
-    @Override
-    public Map getProps() {
-        return props;
-    }
 
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMatrix.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PMatrix.java
@@ -26,7 +26,6 @@ import android.graphics.Color;
 import android.view.MotionEvent;
 import android.view.View;
 
-import java.util.ArrayList;
 import java.util.Map;
 
 import io.phonk.runner.apidoc.annotation.PhonkClass;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PPlot.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PPlot.java
@@ -25,7 +25,6 @@ package io.phonk.runner.apprunner.api.widgets;
 import android.graphics.Color;
 import android.os.Handler;
 import android.os.SystemClock;
-import android.view.View;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -124,7 +123,7 @@ public class PPlot extends PCustomView {
     // rangeY [y1, y2]
 
     public PPlot(AppRunner appRunner, Map initProps) {
-        super(appRunner, initProps);
+        super(appRunner, null);
 
         draw = mydraw;
 
@@ -274,7 +273,7 @@ public class PPlot extends PCustomView {
                     break;
 
                 case "name":
-                    this.name = value.toString();
+                    name = value.toString();
                     break;
 
                 case "plotColor":

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PPlot.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PPlot.java
@@ -36,10 +36,9 @@ import io.phonk.runner.base.utils.AndroidUtils;
 import io.phonk.runner.base.utils.MLog;
 
 @PhonkClass
-public class PPlot extends PCustomView implements PViewMethodsInterface {
+public class PPlot extends PCustomView {
     private static final String TAG = PPlot.class.getSimpleName();
     public final ArrayList<PlotPoint> arrayViz = new ArrayList<>();
-    final PropertiesProxy props = new PropertiesProxy();
     private final Handler handler;
     private final Runnable r;
     private final int mStrokeWeight;
@@ -128,16 +127,15 @@ public class PPlot extends PCustomView implements PViewMethodsInterface {
 
         styler = new PlotStyler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
         });
 
         props.eventOnChange = false;
-        props.put("plotColor", props, appRunner.pUi.theme.get("primary"));
-        props.put("plotWidth", props, AndroidUtils.dpToPixels(mAppRunner.getAppContext(), 2));
-        props.put("textColor", props, "#ffffff");
-        // props.put("borderColor", props, (String) appRunner.pUi.theme.get("secondaryShade"));
-        props.put("background", props, appRunner.pUi.theme.get("secondaryShade"));
+        props.put("plotColor", appRunner.pUi.theme.get("primary"));
+        props.put("plotWidth", AndroidUtils.dpToPixels(mAppRunner.getAppContext(), 2));
+        props.put("textColor", "#ffffff");
+        props.put("background", appRunner.pUi.theme.get("secondaryShade"));
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
         props.change();
@@ -234,23 +232,8 @@ public class PPlot extends PCustomView implements PViewMethodsInterface {
         return this;
     }
 
-    @Override
-    public void set(float x, float y, float w, float h) {
-        styler.setLayoutProps(x, y, w, h);
-    }
-
-    @Override
-    public void setProps(Map props) {
-        WidgetHelper.setProps(this.props, props);
-    }
-
     public void __stop() {
         handler.removeCallbacks(r);
-    }
-
-    @Override
-    public Map getProps() {
-        return props;
     }
 
     static class PlotPoint {

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PPlot.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PPlot.java
@@ -39,7 +39,7 @@ import io.phonk.runner.base.utils.MLog;
 public class PPlot extends PCustomView implements PViewMethodsInterface {
     private static final String TAG = PPlot.class.getSimpleName();
     public final ArrayList<PlotPoint> arrayViz = new ArrayList<>();
-    final StylePropertiesProxy props = new StylePropertiesProxy();
+    final PropertiesProxy props = new PropertiesProxy();
     private final Handler handler;
     private final Runnable r;
     private final int mStrokeWeight;
@@ -127,15 +127,20 @@ public class PPlot extends PCustomView implements PViewMethodsInterface {
         draw = mydraw;
 
         styler = new PlotStyler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
         props.put("plotColor", props, appRunner.pUi.theme.get("primary"));
         props.put("plotWidth", props, AndroidUtils.dpToPixels(mAppRunner.getAppContext(), 2));
         props.put("textColor", props, "#ffffff");
         // props.put("borderColor", props, (String) appRunner.pUi.theme.get("secondaryShade"));
         props.put("background", props, appRunner.pUi.theme.get("secondaryShade"));
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
 
         mAppRunner.whatIsRunning.add(this);
 
@@ -235,8 +240,8 @@ public class PPlot extends PCustomView implements PViewMethodsInterface {
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     public void __stop() {
@@ -262,22 +267,31 @@ public class PPlot extends PCustomView implements PViewMethodsInterface {
         int plotColor = Color.parseColor("#222222");
         float plotWidth = 2;
 
-        PlotStyler(AppRunner appRunner, View view, StylePropertiesProxy props) {
+        PlotStyler(AppRunner appRunner, View view, PropertiesProxy props) {
             super(appRunner, view, props);
         }
 
         @Override
-        public void apply() {
-            super.apply();
+        public void apply(String name, Object value) {
+            super.apply(name, value);
 
-            plotColor = Color.parseColor(mProps.get("plotColor").toString());
-            plotWidth = toFloat(mProps.get("plotWidth"));
+            if (name == null) {
+                apply("plotColor");
+                apply("plotWidth");
+
+            } else {
+                if (value == null) return;
+                switch (name) {
+                    case "plotColor":
+                        plotColor = Color.parseColor(value.toString());
+                        break;
+
+                    case "plotWidth":
+                        plotWidth = toFloat(value);
+                        break;
+                }
+            }
         }
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PScrollView.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PScrollView.java
@@ -30,8 +30,7 @@ public class PScrollView extends ScrollView {
 
     // true if we can scroll (not locked)
     // false if we cannot scroll (locked)
-    private boolean mScrollable = true;
-
+    private boolean mScrollable;
 
     public PScrollView(Context context, boolean mScrollable) {
         super(context);

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSlider.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSlider.java
@@ -25,7 +25,6 @@ package io.phonk.runner.apprunner.api.widgets;
 import android.annotation.SuppressLint;
 import android.graphics.Color;
 import android.view.MotionEvent;
-import android.view.View;
 
 import androidx.core.math.MathUtils;
 
@@ -44,32 +43,30 @@ import io.phonk.runner.base.views.CanvasUtils;
 
 @SuppressLint("ViewConstructor")
 @PhonkClass
-public class PSlider extends PCustomView implements PViewMethodsInterface {
+public class PSlider extends PCustomView {
     private static final String TAG = PSlider.class.getSimpleName();
-
-    public final PropertiesProxy props = new PropertiesProxy();
     private final DecimalFormat df = new DecimalFormat("#.##");
-    public SliderStyler styler;
     private ReturnInterface callbackDrag;
     private ReturnInterface callbackRelease;
     private float currentValue = 0;
-    private float rangeFrom = 0;
-    private float rangeTo = 1;
+    private float rangeFrom;
+    private float rangeTo;
     private String mode = "direct";
     private float initialXValue;
     private float initialYValue;
     private float initialValueWhenTouched = 0;
-    private float userValue = 0;
+    private float userValue;
     private boolean isVertical = false;
     private String text;
     private boolean firstDraw = true;
+
+    private int sliderColor;
 
     public PSlider(final AppRunner appRunner, final Map<String, Object> initProps) {
         super(appRunner, initProps);
 
         setupDrawCallback();
-        setupStyle(appRunner, initProps);
-        decimals(2);
+        setupProps(appRunner, initProps);
     }
 
     private void setupDrawCallback() {
@@ -80,14 +77,14 @@ public class PSlider extends PCustomView implements PViewMethodsInterface {
             canvas.clear();
             canvas.cornerMode(true);
 
-            canvas.fill(styler.slider);
+            canvas.fill(sliderColor);
 
             canvas.strokeWidth((float) styler.borderWidth);
             canvas.stroke(styler.borderColor);
 
             if (firstDraw) {
                 // the value is not correctly set the first time as the canvas is not created yet, so set it now
-                this.value(userValue);
+                value(userValue);
                 firstDraw = false;
             }
             if (isVertical) {
@@ -116,22 +113,24 @@ public class PSlider extends PCustomView implements PViewMethodsInterface {
             canvas.fill(styler.textColor);
             canvas.noStroke();
             canvas.typeface("monospace");
-
             canvas.textSize(AndroidUtils.spToPixels(getContext(), (int) styler.textSize));
-            final String textToDisplay = text != null ? text : df.format(computeCurrentValueForTheUser());
-            canvas.drawTextCentered("" + textToDisplay);
+            canvas.drawTextCentered(text != null ? text : df.format(computeCurrentValueForTheUser()));
         };
     }
 
-    private void setupStyle(final AppRunner appRunner, final Map<String, Object> initProps) {
-        styler = new SliderStyler(appRunner, this, props);
+    private void setupProps(final AppRunner appRunner, final Map<String, Object> initProps) {
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
+            apply(name, value);
         });
 
         props.eventOnChange = false;
-        props.put("slider", null, appRunner.pUi.theme.get("primary"));
+        props.put("decimals", 2);
+        props.put("from", 0);
+        props.put("slider", appRunner.pUi.theme.get("primary"));
+        props.put("to", 1);
+        props.put("value", 0);
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
         props.change();
@@ -140,21 +139,14 @@ public class PSlider extends PCustomView implements PViewMethodsInterface {
     @PhonkMethod(description = "Sets the decimal count", example = "")
     @PhonkMethodParam(params = "decimal count")
     public PSlider decimals(int num) {
-        String formatString = "#";
-        if (num > 0) formatString = "#." + new String(new char[num]).replace("\0", "#");
-        df.applyPattern(formatString);
-        df.setMinimumFractionDigits(num);
-        df.setMaximumFractionDigits(num);
+        props.put("decimals", num);
         return this;
     }
 
     @PhonkMethod(description = "Sets the init value", example = "")
     @PhonkMethodParam(params = "float")
     public PSlider value(final float userValue) {
-        this.userValue = userValue;
-        final int maxCanvasValue = computeMaxCanvasValue();
-        this.currentValue = CanvasUtils.map(userValue, rangeFrom, rangeTo, 0, maxCanvasValue);
-        this.invalidate();
+        props.put("value", userValue);
         return this;
     }
 
@@ -220,15 +212,15 @@ public class PSlider extends PCustomView implements PViewMethodsInterface {
     @PhonkMethod(description = "Sets slider range", example = "")
     @PhonkMethodParam(params = "from and to are floats")
     public PSlider range(float from, float to) {
-        rangeFrom = from;
-        rangeTo = to;
+        props.put("from", from);
+        props.put("to", to);
         return this;
     }
 
     @PhonkMethod(description = "Sets the init value and fire onDrag()", example = "")
     @PhonkMethodParam(params = "float")
     public PSlider valueAndTriggerEvent(float val) {
-        this.value(val);
+        value(val);
         executeCallbackDrag();
         return this;
     }
@@ -239,40 +231,26 @@ public class PSlider extends PCustomView implements PViewMethodsInterface {
         if (callbackDrag != null) callbackDrag.event(ret);
     }
 
-    @Override
-    public void setProps(Map props) {
-        WidgetHelper.setProps(this.props, props);
-    }
-
     @PhonkMethod(description = "Sets the slider mode", example = "")
     @PhonkMethodParam(params = "direct or drag, try them both!")
     public PSlider mode(String mode) {
-        this.mode = mode;
+        props.put("mode", mode);
         return this;
     }
 
-    @Override
-    public Map<String, Object> getProps() {
-        return props;
-    }
 
     @PhonkMethod(description = "Sets the slider orientation", example = "")
     @PhonkMethodParam(params = "boolean")
     public PSlider verticalMode(final boolean isVertical) {
-        this.isVertical = isVertical;
+        props.put("vertical", isVertical);
         return this;
     }
 
     @PhonkMethod(description = "Sets a text inside the slider", example = "")
     @PhonkMethodParam(params = "string")
     public PSlider text(final String text) {
-        this.text = text;
+        props.put("text", text);
         return this;
-    }
-
-    @Override
-    public void set(float x, float y, float w, float h) {
-        styler.setLayoutProps(x, y, w, h);
     }
 
     private void handleHorizontalMovement(final MotionEvent event) {
@@ -299,29 +277,74 @@ public class PSlider extends PCustomView implements PViewMethodsInterface {
         if (callbackRelease != null) callbackRelease.event(ret);
     }
 
-    static class SliderStyler extends Styler {
-        int slider;
+    private void apply(String name, Object value) {
+        if (name == null) {
+            apply("decimals");
+            apply("from");
+            apply("mode");
+            apply("slider");
+            apply("text");
+            apply("to");
+            apply("vertical");
+            apply("value");
 
-        SliderStyler(AppRunner appRunner, View view, PropertiesProxy props) {
-            super(appRunner, view, props);
-        }
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "decimals":
+                    if (value instanceof Number) {
+                        int num = ((Number) value).intValue();
+                        String formatString = "#";
+                        if (num > 0) formatString = "#." + new String(new char[num]).replace("\0", "#");
+                        df.applyPattern(formatString);
+                        df.setMinimumFractionDigits(num);
+                        df.setMaximumFractionDigits(num);
+                    }
+                    break;
 
-        @Override
-        public void apply(String name, Object value) {
-            super.apply(name, value);
+                case "from":
+                    if (value instanceof Number) {
+                        rangeFrom = ((Number) value).floatValue();
+                    }
+                    break;
 
-            if (name == null) {
-                apply("slider");
+                case "mode":
+                    mode = value.toString();
+                    break;
 
-            } else {
-                if (value == null) return;
-                switch (name) {
-                    case "slider":
-                        slider = Color.parseColor((String) value);
-                        break;
-                }
+                case "slider":
+                    sliderColor = Color.parseColor(value.toString());
+                    break;
+
+                case "text":
+                    text = value.toString();
+                    break;
+
+                case "to":
+                    if (value instanceof Number) {
+                        rangeTo = ((Number) value).floatValue();
+                    }
+                    break;
+
+                case "value":
+                    if (value instanceof Number) {
+                        userValue = ((Number) value).floatValue();
+                        currentValue = CanvasUtils.map(userValue, rangeFrom, rangeTo, 0, computeMaxCanvasValue());
+                        invalidate();
+                    }
+                    break;
+
+                case "vertical":
+                    if (value instanceof Boolean) {
+                        isVertical = (Boolean) value;
+                    }
+                    break;
             }
         }
+    }
+
+    private void apply(String name) {
+        apply(name, props.get(name));
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSlider.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSlider.java
@@ -128,7 +128,7 @@ public class PSlider extends PCustomView {
         props.put("decimals", 2);
         props.put("from", 0);
         props.put("slider", appRunner.pUi.theme.get("primary"));
-        props.put("text", "");
+        props.put("text", null);
         props.put("to", 1);
         props.put("value", 0);
         WidgetHelper.fromTo(initProps, props);

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSlider.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSlider.java
@@ -44,7 +44,6 @@ import io.phonk.runner.base.views.CanvasUtils;
 @SuppressLint("ViewConstructor")
 @PhonkClass
 public class PSlider extends PCustomView {
-    private static final String TAG = PSlider.class.getSimpleName();
     private final DecimalFormat df = new DecimalFormat("#.##");
     private ReturnInterface callbackDrag;
     private ReturnInterface callbackRelease;
@@ -63,7 +62,7 @@ public class PSlider extends PCustomView {
     private int sliderColor;
 
     public PSlider(final AppRunner appRunner, final Map<String, Object> initProps) {
-        super(appRunner, initProps);
+        super(appRunner, null);
 
         setupDrawCallback();
         setupProps(appRunner, initProps);
@@ -129,6 +128,7 @@ public class PSlider extends PCustomView {
         props.put("decimals", 2);
         props.put("from", 0);
         props.put("slider", appRunner.pUi.theme.get("primary"));
+        props.put("text", "");
         props.put("to", 1);
         props.put("value", 0);
         WidgetHelper.fromTo(initProps, props);
@@ -237,7 +237,6 @@ public class PSlider extends PCustomView {
         props.put("mode", mode);
         return this;
     }
-
 
     @PhonkMethod(description = "Sets the slider orientation", example = "")
     @PhonkMethodParam(params = "boolean")

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSlider.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSlider.java
@@ -47,7 +47,7 @@ import io.phonk.runner.base.views.CanvasUtils;
 public class PSlider extends PCustomView implements PViewMethodsInterface {
     private static final String TAG = PSlider.class.getSimpleName();
 
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     private final DecimalFormat df = new DecimalFormat("#.##");
     public SliderStyler styler;
     private ReturnInterface callbackDrag;
@@ -125,15 +125,16 @@ public class PSlider extends PCustomView implements PViewMethodsInterface {
 
     private void setupStyle(final AppRunner appRunner, final Map<String, Object> initProps) {
         styler = new SliderStyler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
         props.put("slider", null, appRunner.pUi.theme.get("primary"));
-        props.put("sliderPressed", null, appRunner.pUi.theme.get("primary"));
-        props.put("sliderHeight", null, 20);
-        props.put("sliderBorderSize", null, 0);
-        props.put("sliderBorderColor", null, "#00FFFFFF");
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
     }
 
     @PhonkMethod(description = "Sets the decimal count", example = "")
@@ -239,8 +240,8 @@ public class PSlider extends PCustomView implements PViewMethodsInterface {
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @PhonkMethod(description = "Sets the slider mode", example = "")
@@ -301,21 +302,26 @@ public class PSlider extends PCustomView implements PViewMethodsInterface {
     static class SliderStyler extends Styler {
         int slider;
 
-        SliderStyler(AppRunner appRunner, View view, StylePropertiesProxy props) {
+        SliderStyler(AppRunner appRunner, View view, PropertiesProxy props) {
             super(appRunner, view, props);
         }
 
         @Override
-        public void apply() {
-            super.apply();
+        public void apply(String name, Object value) {
+            super.apply(name, value);
 
-            slider = Color.parseColor((String) mProps.get("slider"));
+            if (name == null) {
+                apply("slider");
+
+            } else {
+                if (value == null) return;
+                switch (name) {
+                    case "slider":
+                        slider = Color.parseColor((String) value);
+                        break;
+                }
+            }
         }
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSpinner.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSpinner.java
@@ -23,6 +23,7 @@
 package io.phonk.runner.apprunner.api.widgets;
 
 import android.graphics.Typeface;
+import android.view.Gravity;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -36,15 +37,21 @@ import io.phonk.runner.apprunner.api.common.ReturnInterface;
 import io.phonk.runner.apprunner.api.common.ReturnObject;
 
 @PhonkClass
-public class PSpinner extends androidx.appcompat.widget.AppCompatSpinner implements PViewMethodsInterface,
-        PTextInterface {
+public class PSpinner extends androidx.appcompat.widget.AppCompatSpinner implements PViewMethodsInterface {
     public final PropertiesProxy props = new PropertiesProxy();
     private String[] mData;
-    // public Styler styler;
-    private Typeface mFont;
+
+    private int align;
 
     public PSpinner(AppRunner appRunner) {
         super(appRunner.getAppContext());
+
+        props.onChange((name, value) -> {
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
+            apply(name, value);
+        });
+
+        props.put("align", "center");
     }
 
     public PSpinner onSelected(final ReturnInterface callback) {
@@ -85,64 +92,51 @@ public class PSpinner extends androidx.appcompat.widget.AppCompatSpinner impleme
         return this;
     }
 
-
-    @Override
-    public View textFont(Typeface font) {
-        mFont = font;
-
-        // this.setTypeface(font);
-        return this;
-    }
-
-    @Override
-    public View textSize(int size) {
-        // this.setTextSize(size);
-        return this;
-    }
-
-    @Override
-    public View textColor(String textColor) {
-        // this.setTextColor(Color.parseColor(textColor));
-        return this;
-    }
-
-    @Override
-    public View textColor(int c) {
-        // this.setTextColor(c);
-        return this;
-    }
-
-    @Override
-    public View textSize(float textSize) {
-        // this.setTextSize(textSize);
-        return this;
-    }
-
-    @Override
-    public View textStyle(int style) {
-        // this.setTypeface(null, style);
-        return this;
-    }
-
-    @Override
-    public View textAlign(int alignment) {
-        setGravity(alignment);
-        return this;
-    }
-
     @Override
     public void set(float x, float y, float w, float h) {
-        // styler.setLayoutProps(x, y, w, h);
+        props.put("x", x);
+        props.put("y", y);
+        props.put("w", w);
+        props.put("h", h);
     }
 
     @Override
     public void setProps(Map props) {
-        // styler.setStyle(style);
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
+    }
+
+    private void apply(String name, Object value) {
+        if (name == null) {
+            apply("align");
+
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "align":
+                    switch (value.toString()) {
+                        case "left":
+                            align = Gravity.LEFT;
+                            break;
+                        case "center":
+                            align = Gravity.CENTER;
+                            break;
+                        case "right":
+                            align = Gravity.RIGHT;
+                            break;
+                    }
+                    setGravity(align);
+                    break;
+            }
+        }
+    }
+
+    private void apply(String name) {
+        apply(name, props.get(name));
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSpinner.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSpinner.java
@@ -38,7 +38,7 @@ import io.phonk.runner.apprunner.api.common.ReturnObject;
 @PhonkClass
 public class PSpinner extends androidx.appcompat.widget.AppCompatSpinner implements PViewMethodsInterface,
         PTextInterface {
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     private String[] mData;
     // public Styler styler;
     private Typeface mFont;
@@ -136,18 +136,13 @@ public class PSpinner extends androidx.appcompat.widget.AppCompatSpinner impleme
     }
 
     @Override
-    public void setProps(Map style) {
+    public void setProps(Map props) {
         // styler.setStyle(style);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSpinner.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSpinner.java
@@ -22,7 +22,6 @@
 
 package io.phonk.runner.apprunner.api.widgets;
 
-import android.graphics.Typeface;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.AdapterView;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSwitch.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSwitch.java
@@ -41,14 +41,18 @@ import io.phonk.runner.apprunner.api.common.ReturnObject;
 @SuppressLint("NewApi")
 @PhonkClass
 public class PSwitch extends SwitchCompat implements PViewMethodsInterface {
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     public final Styler styler;
     private Typeface currentFont;
 
     public PSwitch(AppRunner appRunner) {
         super(appRunner.getAppContext());
         styler = new Styler(appRunner, this, props);
-        styler.apply();
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+        props.change();
         setGravity(Gravity.CENTER);
     }
 
@@ -96,18 +100,13 @@ public class PSwitch extends SwitchCompat implements PViewMethodsInterface {
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSwitch.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSwitch.java
@@ -23,17 +23,12 @@
 package io.phonk.runner.apprunner.api.widgets;
 
 import android.annotation.SuppressLint;
-import android.graphics.Color;
-import android.graphics.Typeface;
-import android.view.Gravity;
 
 import androidx.appcompat.widget.SwitchCompat;
 
 import java.util.Map;
 
 import io.phonk.runner.apidoc.annotation.PhonkClass;
-import io.phonk.runner.apidoc.annotation.PhonkMethod;
-import io.phonk.runner.apidoc.annotation.PhonkMethodParam;
 import io.phonk.runner.apprunner.AppRunner;
 import io.phonk.runner.apprunner.api.common.ReturnInterface;
 import io.phonk.runner.apprunner.api.common.ReturnObject;
@@ -53,7 +48,11 @@ public class PSwitch extends SwitchCompat implements PViewMethodsInterface {
             apply(name, value);
         });
 
+        props.eventOnChange = false;
+        props.put("text", "");
         props.put("textAlign", "center");
+        props.eventOnChange = true;
+        props.change();
     }
 
     public PSwitch onChange(final ReturnInterface callbackfn) {

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSwitch.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PSwitch.java
@@ -43,17 +43,17 @@ import io.phonk.runner.apprunner.api.common.ReturnObject;
 public class PSwitch extends SwitchCompat implements PViewMethodsInterface {
     public final PropertiesProxy props = new PropertiesProxy();
     public final Styler styler;
-    private Typeface currentFont;
 
     public PSwitch(AppRunner appRunner) {
         super(appRunner.getAppContext());
         styler = new Styler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
+            apply(name, value);
         });
-        props.change();
-        setGravity(Gravity.CENTER);
+
+        props.put("textAlign", "center");
     }
 
     public PSwitch onChange(final ReturnInterface callbackfn) {
@@ -68,25 +68,18 @@ public class PSwitch extends SwitchCompat implements PViewMethodsInterface {
     }
 
 
-    @PhonkMethod(description = "Sets the text color", example = "")
-    @PhonkMethodParam(params = {"colorHex"})
     public PSwitch color(String c) {
-        this.setTextColor(Color.parseColor(c));
-
+        props.put("textColor", c);
         return this;
     }
 
-    @PhonkMethod(description = "Sets the background color", example = "")
-    @PhonkMethodParam(params = {"colorHex"})
     public PSwitch background(String c) {
-        this.setBackgroundColor(Color.parseColor(c));
+        props.put("background", c);
         return this;
     }
 
-    @PhonkMethod(description = "Changes the text to the given text", example = "")
-    @PhonkMethodParam(params = {"text"})
     public PSwitch text(String text) {
-        this.setText(text);
+        props.put("text", text);
         return this;
     }
 
@@ -107,6 +100,24 @@ public class PSwitch extends SwitchCompat implements PViewMethodsInterface {
     @Override
     public Map getProps() {
         return props;
+    }
+
+    private void apply(String name, Object value) {
+        if (name == null) {
+            apply("text");
+
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "text":
+                    setText(value.toString());
+                    break;
+            }
+        }
+    }
+
+    private void apply(String name) {
+        apply(name, props.get(name));
     }
 
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PText.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PText.java
@@ -45,8 +45,6 @@ public class PText extends androidx.appcompat.widget.AppCompatTextView implement
         PTextInterface {
     public final PropertiesProxy props = new PropertiesProxy();
     public final Styler styler;
-    private Typeface mFont;
-    private int mStyle;
 
     public PText(AppRunner appRunner, Map initProps) {
         super(appRunner.getAppContext());
@@ -60,8 +58,9 @@ public class PText extends androidx.appcompat.widget.AppCompatTextView implement
 
         props.eventOnChange = false;
         props.put("background", "#00FFFFFF");
-        props.put("textColor", appRunner.pUi.theme.get("textPrimary"));
+        props.put("text", "");
         props.put("textAlign", "left");
+        props.put("textColor", appRunner.pUi.theme.get("textPrimary"));
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
         props.change();

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PText.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PText.java
@@ -53,61 +53,48 @@ public class PText extends androidx.appcompat.widget.AppCompatTextView implement
 
         styler = new Styler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
+            apply(name, value);
         });
 
         props.eventOnChange = false;
-        props.put("background", props, "#00FFFFFF");
-        props.put("textColor", props, appRunner.pUi.theme.get("textPrimary"));
-        // textStyle.put("textSize", textStyle, 12);
-        props.put("textAlign", props, "left");
+        props.put("background", "#00FFFFFF");
+        props.put("textColor", appRunner.pUi.theme.get("textPrimary"));
+        props.put("textAlign", "left");
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
         props.change();
     }
 
     public PText color(String c) {
-        this.setTextColor(Color.parseColor(c));
-
+        props.put("textColor", c);
         return this;
     }
 
     public PText background(String c) {
-        this.setBackgroundColor(Color.parseColor(c));
+        props.put("background", c);
         return this;
     }
 
     @PhonkMethod(description = "Enables/disables the scroll in the text view", example = "")
     @PhonkMethodParam(params = {"size"})
     public PText scrollable(boolean b) {
-        if (b) {
-            this.setMovementMethod(new ScrollingMovementMethod());
-            this.setVerticalScrollBarEnabled(true);
-            // this.setGravity(Gravity.BOTTOM);
-        } else {
-            this.setMovementMethod(null);
-        }
+        props.put("scrollable", b);
         return this;
     }
 
-    @PhonkMethod(description = "Changes the text to the given text", example = "")
-    @PhonkMethodParam(params = {"text"})
     public PText text(String text) {
-        this.setText(text);
+        props.put("text", text);
         return this;
     }
 
-    @PhonkMethod(description = "Changes the text to the given text", example = "")
-    @PhonkMethodParam(params = {"text, text, ..., text"})
     public PText text(String... txt) {
         StringBuilder joinedText = new StringBuilder();
         for (String s : txt) {
             joinedText.append(" ").append(s);
         }
-        this.setText(joinedText.toString());
-
-        return this;
+        return text(joinedText.toString());
     }
 
     public String text() {
@@ -118,55 +105,47 @@ public class PText extends androidx.appcompat.widget.AppCompatTextView implement
     @PhonkMethod(description = "Changes the text to the given html text", example = "")
     @PhonkMethodParam(params = {"htmlText"})
     public PText html(String html) {
-
         Spanned text;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
             text = Html.fromHtml(html, Html.FROM_HTML_MODE_LEGACY);
         } else {
             text = Html.fromHtml(html);
         }
-        this.setText(text);
-
+        props.put("text", text);
         return this;
     }
 
     @PhonkMethod(description = "Appends text to the text view", example = "")
     @PhonkMethodParam(params = {"text"})
     public PText append(String text) {
-        this.setText(getText() + text);
-
-        return this;
+        return text(getText() + text);
     }
 
     @PhonkMethod(description = "Clears the text", example = "")
     public PText clear() {
-        this.setText("");
-        return this;
+        return text("");
     }
 
     @PhonkMethod(description = "Changes the box size of the text", example = "")
     @PhonkMethodParam(params = {"w", "h"})
     public PText boxsize(int w, int h) {
-        this.setWidth(w);
-        this.setHeight(h);
+        props.put("w", w);
+        props.put("h", h);
         return this;
     }
 
     @PhonkMethod(description = "Fits the text to the bounding box", example = "")
     @PhonkMethodParam(params = {"w", "h"})
     public PText autoFitText(boolean b) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return this;
-
-        if (b) TextViewCompat.setAutoSizeTextTypeWithDefaults(this, AUTO_SIZE_TEXT_TYPE_UNIFORM);
-        else TextViewCompat.setAutoSizeTextTypeWithDefaults(this, AUTO_SIZE_TEXT_TYPE_NONE);
+        props.put("autoFit", b);
         return this;
     }
 
     @PhonkMethod(description = "Sets a new position for the text", example = "")
     @PhonkMethodParam(params = {"x", "y"})
     public PText pos(int x, int y) {
-        this.setX(x);
-        this.setY(y);
+        props.put("x", x);
+        props.put("y", y);
         return this;
     }
 
@@ -180,49 +159,52 @@ public class PText extends androidx.appcompat.widget.AppCompatTextView implement
     @PhonkMethod(description = "Centers the text inside the textview", example = "")
     @PhonkMethodParam(params = {"Typeface"})
     public PText center(String centering) {
-        this.setGravity(Gravity.CENTER_VERTICAL);
+        styler.textAlign = Gravity.CENTER_VERTICAL;
+        props.put("textAlign", "custom");
         return this;
     }
 
     public PText textFont(Typeface font) {
-        this.mFont = font;
-        this.setTypeface(font, mStyle);
-        return this;
-    }
-
-    public PText textSize(int size) {
-        this.setTextSize(size);
+        styler.textFont = font;
+        props.put("textFont", "custom");
         return this;
     }
 
     @Override
+    public View textSize(int size) {
+        return textSize((float) size);
+    }
+
+    @Override
     public View textColor(String textColor) {
-        this.setTextColor(Color.parseColor(textColor));
+        props.put("textColor", textColor);
         return this;
     }
 
     @Override
     public View textColor(int c) {
-        this.setTextColor(c);
+        styler.textColor = c;
+        props.put("textColor", "custom");
         return this;
     }
 
     @Override
     public View textSize(float textSize) {
-        this.setTextSize(textSize);
+        props.put("textSize", textSize);
         return this;
     }
 
     @Override
     public View textStyle(int style) {
-        mStyle = style;
-        this.setTypeface(mFont, style);
+        styler.textStyle = style;
+        props.put("textStyle", "custom");
         return this;
     }
 
     @Override
     public View textAlign(int alignment) {
-        this.setGravity(alignment);
+        styler.textAlign = alignment;
+        props.put("textAlign", "custom");
         return this;
     }
 
@@ -241,6 +223,47 @@ public class PText extends androidx.appcompat.widget.AppCompatTextView implement
         return props;
     }
 
+    private void apply(String name, Object value) {
+        if (name == null) {
+            apply("autoFit");
+            apply("scrollable");
+            apply("text");
+
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "autoFit":
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+                    if (value instanceof Boolean) {
+                        TextViewCompat.setAutoSizeTextTypeWithDefaults(this, (Boolean) value ? AUTO_SIZE_TEXT_TYPE_UNIFORM : AUTO_SIZE_TEXT_TYPE_NONE);
+                    }
+                    break;
+
+                case "scrollable":
+                    if (value instanceof Boolean) {
+                        if ((Boolean) value) {
+                            setMovementMethod(new ScrollingMovementMethod());
+                            setVerticalScrollBarEnabled(true);
+                        } else {
+                            setMovementMethod(null);
+                        }
+                    }
+                    break;
+
+                case "text":
+                    if (value instanceof Spanned) {
+                        setText((Spanned) value);
+                    } else {
+                        setText(value.toString());
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void apply(String name) {
+        apply(name, props.get(name));
+    }
 
 
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PText.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PText.java
@@ -43,7 +43,7 @@ import io.phonk.runner.apprunner.AppRunner;
 @PhonkClass
 public class PText extends androidx.appcompat.widget.AppCompatTextView implements PViewMethodsInterface,
         PTextInterface {
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     public final Styler styler;
     private Typeface mFont;
     private int mStyle;
@@ -52,14 +52,19 @@ public class PText extends androidx.appcompat.widget.AppCompatTextView implement
         super(appRunner.getAppContext());
 
         styler = new Styler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
         props.put("background", props, "#00FFFFFF");
         props.put("textColor", props, appRunner.pUi.theme.get("textPrimary"));
         // textStyle.put("textSize", textStyle, 12);
         props.put("textAlign", props, "left");
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
     }
 
     public PText color(String c) {
@@ -227,18 +232,13 @@ public class PText extends androidx.appcompat.widget.AppCompatTextView implement
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PTextList.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PTextList.java
@@ -37,12 +37,12 @@ import io.phonk.runner.base.utils.AndroidUtils;
 @PhonkClass
 public class PTextList extends PList implements PTextInterface {
     final NativeArray data = new NativeArray(0);
-    private boolean mIsAutoScroll = false;
+    private boolean mIsAutoScroll;
     private ReturnInterfaceWithReturn mCreateCallback;
     private ReturnInterfaceWithReturn mUpdateCallback;
 
     public PTextList(AppRunner appRunner, Map initProps) {
-        super(appRunner, initProps);
+        super(appRunner, null);
 
         props.onChange((name, value) -> {
             WidgetHelper.applyViewParam(name, value, props, this, appRunner);
@@ -50,9 +50,12 @@ public class PTextList extends PList implements PTextInterface {
             apply(name, value);
         });
 
-        if (!(initProps != null && initProps.containsKey("textSize"))) {
-            props.put("textSize", AndroidUtils.spToPixels(appRunner.getAppContext(), 6));
-        }
+        props.eventOnChange = false;
+        props.put("autoScroll", false);
+        props.put("textSize", AndroidUtils.spToPixels(appRunner.getAppContext(), 6));
+        WidgetHelper.fromTo(initProps, props);
+        props.eventOnChange = true;
+        props.change();
 
         init();
         super.init(data, mCreateCallback, mUpdateCallback);
@@ -126,6 +129,7 @@ public class PTextList extends PList implements PTextInterface {
         return this;
     }
 
+    @Override
     protected void apply(String name, Object value) {
         super.apply(name, value);
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PTextList.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PTextList.java
@@ -50,7 +50,7 @@ public class PTextList extends PList implements PTextInterface {
             apply(name, value);
         });
 
-        if (initProps != null && !initProps.containsKey("textSize")) {
+        if (!(initProps != null && initProps.containsKey("textSize"))) {
             props.put("textSize", AndroidUtils.spToPixels(appRunner.getAppContext(), 6));
         }
 
@@ -126,7 +126,9 @@ public class PTextList extends PList implements PTextInterface {
         return this;
     }
 
-    private void apply(String name, Object value) {
+    protected void apply(String name, Object value) {
+        super.apply(name, value);
+
         if (name == null) {
             apply("autoScroll");
 
@@ -140,9 +142,5 @@ public class PTextList extends PList implements PTextInterface {
                     break;
             }
         }
-    }
-
-    private void apply(String name) {
-        apply(name, props.get(name));
     }
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PTextList.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PTextList.java
@@ -38,30 +38,27 @@ import io.phonk.runner.base.utils.AndroidUtils;
 
 @PhonkClass
 public class PTextList extends PList implements PTextInterface {
-    final int numCol = 1;
     final NativeArray data = new NativeArray(0);
-    PList list;
     private boolean mIsAutoScroll = false;
     private ReturnInterfaceWithReturn mCreateCallback;
     private ReturnInterfaceWithReturn mUpdateCallback;
 
-    private float mTextSize = -1;
-    private int mTextColor = -1;
-    private Typeface mTextfont;
-
     public PTextList(AppRunner appRunner, Map initProps) {
-        super(appRunner, null);
+        super(appRunner, initProps);
+
+        if (initProps != null && !initProps.containsKey("textSize")) {
+            props.put("textSize", AndroidUtils.spToPixels(appRunner.getAppContext(), 6));
+        }
 
         init();
-        super.numColumns(numCol);
         super.init(data, mCreateCallback, mUpdateCallback);
     }
 
     private void init() {
         mCreateCallback = r -> {
             Map p = new HashMap<String, Object>();
-            p.put("textColor", mTextColor == -1 ? Color.argb(255, 255, 255, 255) : mTextColor);
-            p.put("textSize", mTextSize == -1 ? AndroidUtils.spToPixels(mAppRunner.getAppContext(), 6) : mTextSize);
+            p.put("textColor", props.get("textColor"));
+            p.put("textSize", props.get("textSize"));
             return new PText(mAppRunner, p);
         };
 
@@ -87,42 +84,28 @@ public class PTextList extends PList implements PTextInterface {
         return this;
     }
 
-    public PTextList numColumns(int num) {
-        list.numColumns(num);
-        return this;
-    }
-
     @Override
     public View textFont(Typeface font) {
-        mTextfont = font;
         return this;
     }
 
     @Override
     public View textSize(int size) {
-        mTextSize = size;
-
         return this;
     }
 
     @Override
     public View textColor(String textColor) {
-        mTextColor = Color.parseColor(textColor);
-
         return this;
     }
 
     @Override
     public View textColor(int textColor) {
-        mTextColor = textColor;
-
         return this;
     }
 
     @Override
     public View textSize(float textSize) {
-        mTextSize = textSize;
-
         return this;
     }
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PToggle.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PToggle.java
@@ -32,17 +32,13 @@ import io.phonk.runner.apidoc.annotation.PhonkClass;
 import io.phonk.runner.apprunner.AppRunner;
 import io.phonk.runner.apprunner.api.common.ReturnInterface;
 import io.phonk.runner.apprunner.api.common.ReturnObject;
-import io.phonk.runner.base.utils.MLog;
 
 @PhonkClass
 public class PToggle extends androidx.appcompat.widget.AppCompatToggleButton implements PViewMethodsInterface,
         PTextInterface {
-    private static final String TAG = PToggle.class.getSimpleName();
 
     public final PropertiesProxy props = new PropertiesProxy();
     private final Styler styler;
-    private Typeface mFont;
-    private int mStyle;
 
     private int textOnColor;
     private int textOffColor;
@@ -65,11 +61,12 @@ public class PToggle extends androidx.appcompat.widget.AppCompatToggleButton imp
         props.put("backgroundChecked", appRunner.pUi.theme.get("primaryShade"));
         props.put("borderColor", appRunner.pUi.theme.get("secondaryShade"));
         props.put("borderWidth", appRunner.pUtil.dpToPixels(1));
-        props.put("textOnColor", appRunner.pUi.theme.get("textPrimary"));
-        props.put("textOffColor", appRunner.pUi.theme.get("textPrimary"));
+        props.put("checked", false);
         props.put("text", "Toggle");
-        props.put("textOn", "ON");
         props.put("textOff", "OFF");
+        props.put("textOffColor", appRunner.pUi.theme.get("textPrimary"));
+        props.put("textOn", "ON");
+        props.put("textOnColor", appRunner.pUi.theme.get("textPrimary"));
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
         props.change();

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PToggle.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PToggle.java
@@ -39,7 +39,7 @@ public class PToggle extends androidx.appcompat.widget.AppCompatToggleButton imp
         PTextInterface {
     private static final String TAG = PToggle.class.getSimpleName();
 
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     private final ToggleStyler styler;
     private Typeface mFont;
     private int mStyle;
@@ -48,6 +48,11 @@ public class PToggle extends androidx.appcompat.widget.AppCompatToggleButton imp
         super(appRunner.getAppContext());
 
         styler = new ToggleStyler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
         props.put("textColor", props, appRunner.pUi.theme.get("primary"));
         props.put("background", props, "#00FFFFFF");
@@ -57,9 +62,9 @@ public class PToggle extends androidx.appcompat.widget.AppCompatToggleButton imp
         props.put("borderWidth", props, appRunner.pUtil.dpToPixels(1));
         props.put("textOnColor", props, appRunner.pUi.theme.get("textPrimary"));
         props.put("textOffColor", props, appRunner.pUi.theme.get("textPrimary"));
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
 
         setText("Toggle");
         setTextOn("ON");
@@ -132,7 +137,7 @@ public class PToggle extends androidx.appcompat.widget.AppCompatToggleButton imp
         return this;
     }
 
-    public View text(String label) {
+    public PToggle text(String label) {
         setText(label);
         setTextOn(label);
         setTextOff(label);
@@ -143,7 +148,7 @@ public class PToggle extends androidx.appcompat.widget.AppCompatToggleButton imp
         return getText().toString();
     }
 
-    public View textOn(String label) {
+    public PToggle textOn(String label) {
         setTextOn(label);
         return this;
     }
@@ -152,7 +157,7 @@ public class PToggle extends androidx.appcompat.widget.AppCompatToggleButton imp
         return getTextOn().toString();
     }
 
-    public View textOff(String label) {
+    public PToggle textOff(String label) {
         setTextOff(label);
         return this;
     }
@@ -161,7 +166,7 @@ public class PToggle extends androidx.appcompat.widget.AppCompatToggleButton imp
         return getTextOff().toString();
     }
 
-    public View checked(boolean b) {
+    public PToggle checked(boolean b) {
         setChecked(b);
         return this;
     }
@@ -181,42 +186,55 @@ public class PToggle extends androidx.appcompat.widget.AppCompatToggleButton imp
         int backgroundColor;
         int backgroundCheckedColor;
 
-        ToggleStyler(AppRunner appRunner, View view, StylePropertiesProxy props) {
+        ToggleStyler(AppRunner appRunner, View view, PropertiesProxy props) {
             super(appRunner, view, props);
         }
 
         @Override
-        public void apply() {
-            super.apply();
+        public void apply(String name, Object value) {
+            super.apply(name, value);
 
-            textOnColor = Color.parseColor(mProps.get("textOnColor").toString());
-            textOffColor = Color.parseColor(mProps.get("textOffColor").toString());
-            backgroundColor = Color.parseColor(mProps.get("background").toString());
-            backgroundCheckedColor = Color.parseColor(mProps.get("backgroundChecked").toString());
+            if (name == null) {
+                apply("textOnColor");
+                apply("textOffColor");
+                apply("background");
+                apply("backgroundChecked");
 
-            if (isChecked()) {
-                setTextColor(textOnColor);
-                styler.mBackgroundDrawable.setBackground(backgroundCheckedColor);
             } else {
-                setTextColor(textOffColor);
-                styler.mBackgroundDrawable.setBackground(backgroundColor);
+                if (value == null) return;
+                switch (name) {
+                    case "textOnColor":
+                        textOnColor = Color.parseColor(value.toString());
+                        if (isChecked()) setTextColor(textOnColor);
+                        break;
+
+                    case "textOffColor":
+                        textOffColor = Color.parseColor(value.toString());
+                        if (!isChecked()) setTextColor(textOffColor);
+                        break;
+
+                    case "background":
+                        backgroundColor = Color.parseColor(value.toString());
+                        if (!isChecked()) styler.mBackgroundDrawable.setBackground(backgroundColor);
+                        break;
+
+                    case "backgroundChecked":
+                        backgroundCheckedColor = Color.parseColor(value.toString());
+                        if (isChecked()) styler.mBackgroundDrawable.setBackground(backgroundCheckedColor);
+                        break;
+                }
             }
         }
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PToolbar.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PToolbar.java
@@ -25,7 +25,6 @@ package io.phonk.runner.apprunner.api.widgets;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
-import android.graphics.Paint;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
@@ -42,8 +41,6 @@ import io.phonk.runner.apprunner.api.ProtoBase;
 public class PToolbar extends ProtoBase {
     private final AppRunner mAppRunner;
     private final ActionBar mToolbar;
-    private int currentColor;
-    private Paint paint;
 
     public PToolbar(AppRunner appRunner, ActionBar toolbar) {
         super(appRunner);

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PTouchPad.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PTouchPad.java
@@ -37,10 +37,9 @@ import io.phonk.runner.base.utils.MLog;
 import io.phonk.runner.base.views.CanvasUtils;
 
 @PhonkClass
-public class PTouchPad extends PCustomView implements PViewMethodsInterface {
+public class PTouchPad extends PCustomView {
     private static final String TAG = PTouchPad.class.getSimpleName();
 
-    public final PropertiesProxy props = new PropertiesProxy();
     public final TouchPadStyler styler;
     final PLooper looper = new PLooper(mAppRunner, 5, () -> {
         invalidate();
@@ -90,16 +89,16 @@ public class PTouchPad extends PCustomView implements PViewMethodsInterface {
 
         styler = new TouchPadStyler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
         });
 
         props.eventOnChange = false;
-        props.put("padSize", props, appRunner.pUtil.dpToPixels(50));
-        props.put("background", props, appRunner.pUi.theme.get("primaryShade"));
-        props.put("padColor", props, appRunner.pUi.theme.get("primary"));
-        props.put("padBorderColor", props, appRunner.pUi.theme.get("primary"));
-        props.put("padBorderSize", props, appRunner.pUtil.dpToPixels(2));
+        props.put("padSize", appRunner.pUtil.dpToPixels(50));
+        props.put("background", appRunner.pUi.theme.get("primaryShade"));
+        props.put("padColor", appRunner.pUi.theme.get("primary"));
+        props.put("padBorderColor", appRunner.pUi.theme.get("primary"));
+        props.put("padBorderSize", appRunner.pUtil.dpToPixels(2));
         WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
         props.change();
@@ -183,11 +182,6 @@ public class PTouchPad extends PCustomView implements PViewMethodsInterface {
         }
     }
 
-    @Override
-    public void set(float x, float y, float w, float h) {
-        styler.setLayoutProps(x, y, w, h);
-    }
-
     static class TouchPadStyler extends Styler {
         float padSize;
         int padColor;
@@ -229,16 +223,6 @@ public class PTouchPad extends PCustomView implements PViewMethodsInterface {
                 }
             }
         }
-    }
-
-    @Override
-    public void setProps(Map props) {
-        WidgetHelper.setProps(this.props, props);
-    }
-
-    @Override
-    public Map getProps() {
-        return props;
     }
 
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PTouchPad.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PTouchPad.java
@@ -83,7 +83,7 @@ public class PTouchPad extends PCustomView {
     private float rangeYTo = 1.0f;
 
     public PTouchPad(AppRunner appRunner, Map initProps) {
-        super(appRunner, initProps);
+        super(appRunner, null);
 
         draw = mydraw;
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PViewItemAdapter.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PViewItemAdapter.java
@@ -35,7 +35,6 @@ import io.phonk.runner.apprunner.api.common.ReturnObject;
 
 
 public class PViewItemAdapter extends RecyclerView.Adapter<PViewItemAdapter.ViewHolder> {
-    private static final String TAG = PViewItemAdapter.class.getSimpleName();
     private final ReturnInterfaceWithReturn mCreating;
     private final ReturnInterfaceWithReturn mBinding;
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PViewMethodsInterface.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PViewMethodsInterface.java
@@ -30,7 +30,5 @@ public interface PViewMethodsInterface {
 
     Map getProps();
 
-    void setProps(Map style);
-
-    int id();
+    void setProps(Map props);
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PViewPager.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PViewPager.java
@@ -38,7 +38,7 @@ import io.phonk.runner.apprunner.AppRunner;
 @PhonkClass
 public class PViewPager extends ViewPager implements PViewMethodsInterface {
     // this is a props proxy for the user
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     // the props are transformed / accessed using the styler object
     public final Styler styler;
     final MyAdapter mAdapter;
@@ -47,10 +47,15 @@ public class PViewPager extends ViewPager implements PViewMethodsInterface {
         super(appRunner.getAppContext());
 
         styler = new Styler(appRunner, this, props);
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+
         props.eventOnChange = false;
-        Styler.fromTo(initProps, props);
+        WidgetHelper.fromTo(initProps, props);
         props.eventOnChange = true;
-        styler.apply();
+        props.change();
         setPageMargin(0);
         setPadding(0, 0, 0, 0);
 
@@ -109,17 +114,12 @@ public class PViewPager extends ViewPager implements PViewMethodsInterface {
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PViewPager.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PViewPager.java
@@ -48,7 +48,7 @@ public class PViewPager extends ViewPager implements PViewMethodsInterface {
 
         styler = new Styler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
         });
 

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PWebView.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PWebView.java
@@ -47,7 +47,7 @@ public class PWebView extends WebView implements PViewMethodsInterface {
         mAppRunner = appRunner;
         styler = new Styler(appRunner, this, props);
         props.onChange((name, value) -> {
-            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            WidgetHelper.applyViewParam(name, value, props, this, appRunner);
             styler.apply(name, value);
         });
         props.change();

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PWebView.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PWebView.java
@@ -38,7 +38,7 @@ import io.phonk.runner.apprunner.AppRunner;
 @SuppressLint("JavascriptInterface")
 @PhonkClass
 public class PWebView extends WebView implements PViewMethodsInterface {
-    public final StylePropertiesProxy props = new StylePropertiesProxy();
+    public final PropertiesProxy props = new PropertiesProxy();
     private final AppRunner mAppRunner;
     private final Styler styler;
 
@@ -46,7 +46,11 @@ public class PWebView extends WebView implements PViewMethodsInterface {
         super(appRunner.getAppContext());
         mAppRunner = appRunner;
         styler = new Styler(appRunner, this, props);
-        styler.apply();
+        props.onChange((name, value) -> {
+            WidgetHelper.applyLayoutParams(name, value, props, this, appRunner);
+            styler.apply(name, value);
+        });
+        props.change();
 
         // this.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
         WebSettings webSettings = this.getSettings();
@@ -135,18 +139,13 @@ public class PWebView extends WebView implements PViewMethodsInterface {
     }
 
     @Override
-    public void setProps(Map style) {
-        styler.setProps(style);
+    public void setProps(Map props) {
+        WidgetHelper.setProps(this.props, props);
     }
 
     @Override
     public Map getProps() {
         return props;
-    }
-
-    @Override
-    public int id() {
-        return getId();
     }
 
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PWindow.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PWindow.java
@@ -35,7 +35,6 @@ import io.phonk.runner.apidoc.annotation.PhonkMethod;
 import io.phonk.runner.apidoc.annotation.PhonkMethodParam;
 
 public class PWindow extends RelativeLayout {
-    private static final String TAG = PWindow.class.getSimpleName();
 
     private final RelativeLayout mBar;
     private final LinearLayout mMainContainer;
@@ -44,7 +43,6 @@ public class PWindow extends RelativeLayout {
 
     public PWindow(Context context) {
         super(context);
-        int currentColor = Color.argb(255, 255, 255, 255);
 
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         inflater.inflate(R.layout.pwidget_window, this, true);

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PropertiesProxy.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PropertiesProxy.java
@@ -35,7 +35,6 @@ import io.phonk.runner.base.utils.GSONUtil;
 
 public class PropertiesProxy implements Scriptable, Map<String, Object> {
 
-    private static final java.lang.String TAG = PropertiesProxy.class.getSimpleName();
     public final ReturnObject values = new ReturnObject();
     public boolean eventOnChange = true;
     private OnChangeListener changeListener;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PropertiesProxy.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/PropertiesProxy.java
@@ -22,6 +22,7 @@
 
 package io.phonk.runner.apprunner.api.widgets;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.mozilla.javascript.Scriptable;
 
 import java.util.Collection;
@@ -32,15 +33,15 @@ import java.util.Set;
 import io.phonk.runner.apprunner.api.common.ReturnObject;
 import io.phonk.runner.base.utils.GSONUtil;
 
-public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
+public class PropertiesProxy implements Scriptable, Map<String, Object> {
 
-    private static final java.lang.String TAG = StylePropertiesProxy.class.getSimpleName();
+    private static final java.lang.String TAG = PropertiesProxy.class.getSimpleName();
     public final ReturnObject values = new ReturnObject();
     public boolean eventOnChange = true;
     private OnChangeListener changeListener;
 
-    public StylePropertiesProxy() {
-
+    public PropertiesProxy() {
+        put("id", RandomStringUtils.randomAlphanumeric(8));
     }
 
     @Override
@@ -52,7 +53,7 @@ public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
     public Object get(String name, Scriptable start) {
         // MLog.d(TAG, "get 1: " + name + " " + values.get(name));
 
-        return values.get(name);
+        return values.get(name, start);
     }
 
     @Override
@@ -64,7 +65,7 @@ public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
     @Override
     public boolean has(String name, Scriptable start) {
         // TODO Auto-generated method stub
-        return false;
+        return values.has(name, start);
     }
 
     @Override
@@ -76,9 +77,9 @@ public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
     @Override
     public void put(String name, Scriptable start, Object value) {
         // MLog.d(TAG, "put 1: " + name + " : " + value + " " + changeListener);
-        values.put(name, value);
+        values.put(name, start, value);
 
-        if (changeListener != null && eventOnChange) changeListener.event(name, value);
+        change(name, value);
     }
 
     @Override
@@ -89,8 +90,8 @@ public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
 
     @Override
     public void delete(String name) {
-        // TODO Auto-generated method stub
-
+        values.delete(name);
+        change(name, null);
     }
 
     @Override
@@ -124,20 +125,17 @@ public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
 
     @Override
     public Object[] getIds() {
-        // TODO Auto-generated method stub
-        return null;
+        return values.getIds();
     }
 
     @Override
     public Object getDefaultValue(Class<?> hint) {
-        // TODO Auto-generated method stub
-        return null;
+        return values.getDefaultValue(hint);
     }
 
     @Override
     public boolean hasInstance(Scriptable instance) {
-        // TODO Auto-generated method stub
-        return false;
+        return values.hasInstance(instance);
     }
 
     @Override
@@ -157,7 +155,7 @@ public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
 
     @Override
     public boolean containsValue(Object value) {
-        return values.containsKey(value);
+        return values.containsValue(value);
     }
 
     @Override
@@ -169,14 +167,16 @@ public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
     @Override
     public Object put(String key, Object value) {
         // MLog.d(TAG, "put 3: " + key + " " + values.get(key));
-        values.put(key, value);
-
-        return value;
+        Object previousValue = values.put(key, value);
+        change(key, value);
+        return previousValue;
     }
 
     @Override
     public Object remove(Object key) {
-        return values.remove(key);
+        Object value = values.remove((String) key);
+        change((String) key, null);
+        return value;
     }
 
     @Override
@@ -184,11 +184,13 @@ public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
         // MLog.d(TAG, "putAll: ");
 
         values.putAll(m);
+        change(null, null);
     }
 
     @Override
     public void clear() {
         values.clear();
+        change(null, null);
     }
 
     @Override
@@ -210,8 +212,8 @@ public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
         changeListener = listener;
     }
 
-    public void apply(HashMap<String, Object> styleProps) {
-        this.putAll(styleProps);
+    public void apply(HashMap<String, Object> props) {
+        putAll(props);
     }
 
     public String toString() {
@@ -220,5 +222,13 @@ public class StylePropertiesProxy implements Scriptable, Map<String, Object> {
 
     public interface OnChangeListener {
         void event(String name, Object value);
+    }
+
+    public void change() {
+        change(null, null);
+    }
+
+    private void change(String name, Object value) {
+        if (changeListener != null && eventOnChange) changeListener.event(name, value);
     }
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/Styler.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/Styler.java
@@ -29,6 +29,7 @@ import android.graphics.Typeface;
 import android.graphics.drawable.StateListDrawable;
 import android.view.Gravity;
 import android.view.View;
+import android.widget.TextView;
 
 import io.phonk.runner.apprunner.AppRunner;
 import io.phonk.runner.base.utils.MLog;
@@ -64,9 +65,9 @@ public class Styler {
     float padding;
     int textColor;
     float textSize;
-    String textFont;
-    String textStyle;
-    String textAlign;
+    Typeface textFont;
+    int textStyle;
+    int textAlign;
 
     Styler(AppRunner appRunner, View view, PropertiesProxy props) {
         mAppRunner = appRunner;
@@ -217,74 +218,78 @@ public class Styler {
                     break;
 
                 case "textAlign":
-                    textAlign = value.toString();
-                    if (mView instanceof PTextInterface) {
-                        int tAlignment = TEXT_ALIGNMENT_TEXT_START;
-                        switch (textAlign) {
-                            case "left":
-                                tAlignment = Gravity.CENTER_VERTICAL | Gravity.LEFT;
-                                break;
-                            case "center":
-                                tAlignment = Gravity.CENTER;
-                                break;
-
-                            case "right":
-                                tAlignment = Gravity.CENTER_VERTICAL | Gravity.RIGHT;
-                                break;
-                        }
-                        ((PTextInterface) mView).textAlign(tAlignment);
+                    switch (value.toString()) {
+                        case "left":
+                            textAlign = Gravity.CENTER_VERTICAL | Gravity.LEFT;
+                            break;
+                        case "center":
+                            textAlign = Gravity.CENTER;
+                            break;
+                        case "right":
+                            textAlign = Gravity.CENTER_VERTICAL | Gravity.RIGHT;
+                            break;
+                    }
+                    if (mView instanceof TextView) {
+                        ((TextView) mView).setGravity(textAlign);
                     }
                     break;
 
                 case "textColor":
-                    textColor = Color.parseColor(value.toString());
-                    if (mView instanceof PTextInterface) {
-                        ((PTextInterface) mView).textColor(textColor);
+                    String colorString = value.toString();
+                    if (!colorString.equals("custom")) {
+                        textColor = Color.parseColor(colorString);
+                    }
+                    if (mView instanceof TextView) {
+                        ((TextView) mView).setTextColor(textColor);
                     }
                     break;
 
                 case "textFont":
-                    textFont = value.toString();
-                    if (mView instanceof PTextInterface) {
-                        Typeface font = Typeface.DEFAULT;
-                        switch (textFont) {
-                            case "serif":
-                                font = Typeface.SERIF;
-                                break;
-                            case "sansSerif":
-                                font = Typeface.SANS_SERIF;
-                                break;
-                            case "monospace":
-                                font = Typeface.MONOSPACE;
-                                break;
-                        }
-                        ((PTextInterface) mView).textFont(font);
+                    switch (value.toString()) {
+                        case "default":
+                            textFont = Typeface.DEFAULT;
+                            break;
+                        case "serif":
+                            textFont = Typeface.SERIF;
+                            break;
+                        case "sansSerif":
+                            textFont = Typeface.SANS_SERIF;
+                            break;
+                        case "monospace":
+                            textFont = Typeface.MONOSPACE;
+                            break;
+                    }
+                    if (mView instanceof TextView) {
+                        ((TextView) mView).setTypeface(textFont, textStyle);
                     }
                     break;
 
                 case "textSize":
-                    textSize = toFloat(value);
-                    if (mView instanceof PTextInterface) {
-                        ((PTextInterface) mView).textSize(textSize);;
+                    if (value instanceof Number) {
+                        textSize = toFloat(value);
+                        if (mView instanceof TextView) {
+                            ((TextView) mView).setTextSize(textSize);
+                        }
                     }
                     break;
 
                 case "textStyle":
-                    textStyle = value.toString();
-                    if (mView instanceof PTextInterface) {
-                        int typeFaceStyle = Typeface.NORMAL;
-                        switch (textStyle) {
-                            case "bold":
-                                typeFaceStyle = Typeface.BOLD;
-                                break;
-                            case "boldItalic":
-                                typeFaceStyle = Typeface.BOLD_ITALIC;
-                                break;
-                            case "italic":
-                                typeFaceStyle = Typeface.ITALIC;
-                                break;
-                        }
-                        ((PTextInterface) mView).textStyle(typeFaceStyle);
+                    switch (value.toString()) {
+                        case "normal":
+                            textStyle = Typeface.NORMAL;
+                            break;
+                        case "bold":
+                            textStyle = Typeface.BOLD;
+                            break;
+                        case "boldItalic":
+                            textStyle = Typeface.BOLD_ITALIC;
+                            break;
+                        case "italic":
+                            textStyle = Typeface.ITALIC;
+                            break;
+                    }
+                    if (mView instanceof TextView) {
+                        ((TextView) mView).setTypeface(textFont, textStyle);
                     }
                     break;
             }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/Styler.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/Styler.java
@@ -22,8 +22,6 @@
 
 package io.phonk.runner.apprunner.api.widgets;
 
-import static android.view.View.TEXT_ALIGNMENT_TEXT_START;
-
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.StateListDrawable;
@@ -40,16 +38,11 @@ public class Styler {
     final View mView;
     final AppRunner mAppRunner;
     final MyRoundCornerDrawable mBackgroundDrawable = new MyRoundCornerDrawable();
-    // MyRoundCornerDrawable mActiveDrawable = new MyRoundCornerDrawable();
     final MyRoundCornerDrawable mPressedDrawable = new MyRoundCornerDrawable();
     final MyRoundCornerDrawable mSelectedDrawable = new MyRoundCornerDrawable();
     final MyRoundCornerDrawable mCheckedDrawable = new MyRoundCornerDrawable();
     final MyRoundCornerDrawable mHoveredDrawable = new MyRoundCornerDrawable();
     final StateListDrawable mStateListDrawable = new StateListDrawable();
-
-    // String animInBefore;
-    // String animIn;
-    // String animOut;
 
     // common properties
     final String mViewName;

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/Styler.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/Styler.java
@@ -29,16 +29,13 @@ import android.graphics.Typeface;
 import android.graphics.drawable.StateListDrawable;
 import android.view.Gravity;
 import android.view.View;
-import android.view.ViewGroup;
-
-import java.util.Map;
 
 import io.phonk.runner.apprunner.AppRunner;
 import io.phonk.runner.base.utils.MLog;
 
 public class Styler {
     private static final java.lang.String TAG = Styler.class.getSimpleName();
-    public final StylePropertiesProxy mProps;
+    public final PropertiesProxy mProps;
     final View mView;
     final AppRunner mAppRunner;
     final MyRoundCornerDrawable mBackgroundDrawable = new MyRoundCornerDrawable();
@@ -71,15 +68,7 @@ public class Styler {
     String textStyle;
     String textAlign;
 
-    /*
-    String src;
-    String srcPressed;
-    */
-
-    private int mWidth;
-    private int mHeight;
-
-    Styler(AppRunner appRunner, View view, StylePropertiesProxy props) {
+    Styler(AppRunner appRunner, View view, PropertiesProxy props) {
         mAppRunner = appRunner;
 
         mView = view;
@@ -100,218 +89,205 @@ public class Styler {
 
         // get default styles
         resetStyle();
-
-        // when property changes then reapply them
-        props.onChange((name, value) -> {
-            /*
-            switch (name) {
-                case "x":
-                    setX(value);
-                    break;
-                case "y":
-                    setY(value);
-                    break;
-                case "w":
-                    setWidth(value);
-                    break;
-                case "h":
-                    setHeight(value);
-                    break;
-            }
-            */
-            apply();
-        });
     }
 
     public void resetStyle() {
-        StylePropertiesProxy style = mAppRunner.pUi.getStyle();
-        fromTo(style, mProps);
+        String id = (String) mProps.get("id");
+        WidgetHelper.fromTo(mAppRunner.pUi.getProps(), mProps);
+        mProps.put("id", id);
     }
 
     public void apply() {
-        StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+        apply(null, null);
+    }
 
-        opacity = toFloat(mProps.get("opacity"));
-        background = Color.parseColor(mProps.get("background").toString());
+    protected void apply(String name) {
+        apply(name, mProps.get(name));
+    }
 
-        backgroundHover = Color.parseColor(mProps.get("backgroundHover").toString());
-        backgroundPressed = Color.parseColor(mProps.get("backgroundPressed").toString());
-        backgroundSelected = Color.parseColor(mProps.get("backgroundSelected").toString());
-        backgroundChecked = Color.parseColor(mProps.get("backgroundChecked").toString());
-        borderWidth = toFloat(mProps.get("borderWidth"));
-        borderColor = Color.parseColor(mProps.get("borderColor").toString());
-        borderRadius = toFloat(mProps.get("borderRadius"));
+    public void apply(String name, Object value) {
+        if (name == null) {
+            apply("background");
+            apply("backgroundChecked");
+            apply("backgroundHover");
+            apply("backgroundPressed");
+            apply("backgroundSelected");
+            apply("borderColor");
+            apply("borderRadius");
+            apply("borderWidth");
+            apply("opacity");
+            apply("padding");
+            apply("textAlign");
+            apply("textColor");
+            apply("textFont");
+            apply("textSize");
+            apply("textStyle");
 
-        textColor = Color.parseColor(mProps.get("textColor").toString());
-        textSize = toFloat(mProps.get("textSize"));
-        textFont = mProps.get("textFont").toString();
-        textStyle = mProps.get("textStyle").toString();
-        textAlign = mProps.get("textAlign").toString();
-        padding = toFloat(mProps.get("padding"));
-
-        // individual paddings have preference over general
-        float paddingLeft = padding;
-        float paddingTop = padding;
-        float paddingRight = padding;
-        float paddingBottom = padding;
-
-        try {
-            paddingLeft = toFloat(mProps.get("paddingLeft"));
-        } catch (Exception ignored) {
-        }
-        try {
-            paddingTop = toFloat(mProps.get("paddingTop"));
-        } catch (Exception ignored) {
-        }
-        try {
-            paddingRight = toFloat(mProps.get("paddingRight"));
-        } catch (Exception ignored) {
-        }
-        try {
-            paddingBottom = toFloat(mProps.get("paddingBottom"));
-        } catch (Exception ignored) {
-        }
-
-        /*
-        src = props.get("src").toString();
-        srcPressed = props.get("srcPressed").toString();
-
-
-        // animInBefore = props.get("animInBefore").toString();
-        // animIn = props.get("animIn").toString();
-        // animOut = props.get("animOut").toString();
-        */
-
-        mView.setAlpha(opacity);
-
-        mView.setPadding((int) paddingLeft, (int) paddingTop, (int) paddingRight, (int) paddingBottom);
-
-        // set background
-        mBackgroundDrawable.setBackground(background);
-        // mActiveDrawable.setBackground(0x0000FF00);
-        mPressedDrawable.setBackground(backgroundPressed);
-        mSelectedDrawable.setBackground(backgroundSelected);
-        mCheckedDrawable.setBackground(backgroundChecked);
-        mHoveredDrawable.setBackground(backgroundHover);
-
-        mBackgroundDrawable.setBorderRadius((int) borderRadius);
-        // mActiveDrawable.setBorderRadius((int) borderRadius);
-
-        mPressedDrawable.setBorderRadius((int) borderRadius);
-        mSelectedDrawable.setBorderRadius((int) borderRadius);
-        mCheckedDrawable.setBorderRadius((int) borderRadius);
-        mHoveredDrawable.setBorderRadius((int) borderRadius);
-
-        mBackgroundDrawable.setBorderWidth((int) borderWidth);
-        mPressedDrawable.setBorderWidth((int) borderWidth);
-        mSelectedDrawable.setBorderWidth((int) borderWidth);
-        mCheckedDrawable.setBorderWidth((int) borderWidth);
-        mHoveredDrawable.setBorderWidth((int) borderWidth);
-
-        mBackgroundDrawable.setBorderColor(borderColor);
-        mPressedDrawable.setBorderColor(borderColor);
-        mSelectedDrawable.setBorderColor(borderColor);
-        mCheckedDrawable.setBorderColor(borderColor);
-        mHoveredDrawable.setBorderColor(borderColor);
-
-        if (mView instanceof PTextInterface) {
-            PTextInterface v = (PTextInterface) mView;
-            v.textColor(textColor);
-            v.textSize(textSize);
-
-            Typeface font = Typeface.DEFAULT;
-            switch (textFont) {
-                case "serif":
-                    font = Typeface.SERIF;
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "background":
+                    background = Color.parseColor(value.toString());
+                    mBackgroundDrawable.setBackground(background);
                     break;
-                case "sansSerif":
-                    font = Typeface.SANS_SERIF;
+
+                case "backgroundChecked":
+                    backgroundChecked = Color.parseColor(value.toString());
+                    mCheckedDrawable.setBackground(backgroundChecked);
                     break;
-                case "monospace":
-                    MLog.d(TAG, mViewName + " yep!");
-                    font = Typeface.MONOSPACE;
+
+                case "backgroundHover":
+                    backgroundHover = Color.parseColor(value.toString());
+                    mHoveredDrawable.setBackground(backgroundHover);
+                    break;
+
+                case "backgroundPressed":
+                    backgroundPressed = Color.parseColor(value.toString());
+                    mPressedDrawable.setBackground(backgroundPressed);
+                    break;
+
+                case "backgroundSelected":
+                    backgroundSelected = Color.parseColor(value.toString());
+                    mSelectedDrawable.setBackground(backgroundSelected);
+                    break;
+
+                case "borderColor":
+                    borderColor = Color.parseColor(value.toString());
+                    mBackgroundDrawable.setBorderColor(borderColor);
+                    mPressedDrawable.setBorderColor(borderColor);
+                    mSelectedDrawable.setBorderColor(borderColor);
+                    mCheckedDrawable.setBorderColor(borderColor);
+                    mHoveredDrawable.setBorderColor(borderColor);
+                    break;
+
+                case "borderRadius":
+                    borderRadius = toFloat(value);
+                    mBackgroundDrawable.setBorderRadius((int) borderRadius);
+                    mPressedDrawable.setBorderRadius((int) borderRadius);
+                    mSelectedDrawable.setBorderRadius((int) borderRadius);
+                    mCheckedDrawable.setBorderRadius((int) borderRadius);
+                    mHoveredDrawable.setBorderRadius((int) borderRadius);
+                    break;
+
+                case "borderWidth":
+                    borderWidth = toFloat(value);
+                    mBackgroundDrawable.setBorderWidth((int) borderWidth);
+                    mPressedDrawable.setBorderWidth((int) borderWidth);
+                    mSelectedDrawable.setBorderWidth((int) borderWidth);
+                    mCheckedDrawable.setBorderWidth((int) borderWidth);
+                    mHoveredDrawable.setBorderWidth((int) borderWidth);
+                    break;
+
+                case "opacity":
+                    opacity = toFloat(value);
+                    mView.setAlpha(opacity);
+                    break;
+
+                case "padding":
+                case "paddingLeft":
+                case "paddingTop":
+                case "paddingRight":
+                case "paddingBottom":
+                    padding = toFloat(mProps.get("padding"));
+
+                    float paddingLeft = padding;
+                    float paddingTop = padding;
+                    float paddingRight = padding;
+                    float paddingBottom = padding;
+
+                    // individual paddings have preference over general
+                    try {
+                        paddingLeft = toFloat(mProps.get("paddingLeft"));
+                    } catch (Exception ignored) {
+                    }
+                    try {
+                        paddingTop = toFloat(mProps.get("paddingTop"));
+                    } catch (Exception ignored) {
+                    }
+                    try {
+                        paddingRight = toFloat(mProps.get("paddingRight"));
+                    } catch (Exception ignored) {
+                    }
+                    try {
+                        paddingBottom = toFloat(mProps.get("paddingBottom"));
+                    } catch (Exception ignored) {
+                    }
+
+                    mView.setPadding((int) paddingLeft, (int) paddingTop, (int) paddingRight, (int) paddingBottom);
+                    break;
+
+                case "textAlign":
+                    textAlign = value.toString();
+                    if (mView instanceof PTextInterface) {
+                        int tAlignment = TEXT_ALIGNMENT_TEXT_START;
+                        switch (textAlign) {
+                            case "left":
+                                tAlignment = Gravity.CENTER_VERTICAL | Gravity.LEFT;
+                                break;
+                            case "center":
+                                tAlignment = Gravity.CENTER;
+                                break;
+
+                            case "right":
+                                tAlignment = Gravity.CENTER_VERTICAL | Gravity.RIGHT;
+                                break;
+                        }
+                        ((PTextInterface) mView).textAlign(tAlignment);
+                    }
+                    break;
+
+                case "textColor":
+                    textColor = Color.parseColor(value.toString());
+                    if (mView instanceof PTextInterface) {
+                        ((PTextInterface) mView).textColor(textColor);
+                    }
+                    break;
+
+                case "textFont":
+                    textFont = value.toString();
+                    if (mView instanceof PTextInterface) {
+                        Typeface font = Typeface.DEFAULT;
+                        switch (textFont) {
+                            case "serif":
+                                font = Typeface.SERIF;
+                                break;
+                            case "sansSerif":
+                                font = Typeface.SANS_SERIF;
+                                break;
+                            case "monospace":
+                                font = Typeface.MONOSPACE;
+                                break;
+                        }
+                        ((PTextInterface) mView).textFont(font);
+                    }
+                    break;
+
+                case "textSize":
+                    textSize = toFloat(value);
+                    if (mView instanceof PTextInterface) {
+                        ((PTextInterface) mView).textSize(textSize);;
+                    }
+                    break;
+
+                case "textStyle":
+                    textStyle = value.toString();
+                    if (mView instanceof PTextInterface) {
+                        int typeFaceStyle = Typeface.NORMAL;
+                        switch (textStyle) {
+                            case "bold":
+                                typeFaceStyle = Typeface.BOLD;
+                                break;
+                            case "boldItalic":
+                                typeFaceStyle = Typeface.BOLD_ITALIC;
+                                break;
+                            case "italic":
+                                typeFaceStyle = Typeface.ITALIC;
+                                break;
+                        }
+                        ((PTextInterface) mView).textStyle(typeFaceStyle);
+                    }
                     break;
             }
-            v.textFont(font);
-
-            int typeFaceStyle = Typeface.NORMAL;
-            switch (textStyle) {
-                case "bold":
-                    typeFaceStyle = Typeface.BOLD;
-                    break;
-                case "boldItalic":
-                    typeFaceStyle = Typeface.BOLD_ITALIC;
-                    break;
-                case "italic":
-                    typeFaceStyle = Typeface.ITALIC;
-                    break;
-            }
-            v.textStyle(typeFaceStyle);
-
-            int tAlignment = TEXT_ALIGNMENT_TEXT_START;
-            switch (textAlign) {
-                case "left":
-                    tAlignment = Gravity.CENTER_VERTICAL | Gravity.LEFT;
-                    break;
-                case "center":
-                    tAlignment = Gravity.CENTER;
-                    break;
-
-                case "right":
-                    tAlignment = Gravity.CENTER_VERTICAL | Gravity.RIGHT;
-                    break;
-            }
-            v.textAlign(tAlignment);
-        }
-    }
-
-    public static void fromTo(Map<String, Object> styleFrom, StylePropertiesProxy styleTo) {
-        if (styleFrom == null) return;
-
-        for (Map.Entry<String, Object> entry : styleFrom.entrySet()) {
-            styleTo.put(entry.getKey(), styleTo, entry.getValue());
-        }
-    }
-
-    public void setX(Object value) {
-        getScreenSize();
-        int val = mAppRunner.pUtil.sizeToPixels(value, mWidth);
-
-        if (mView.getLayoutParams() instanceof FixedLayout.LayoutParams) {
-            FixedLayout.LayoutParams lp = (FixedLayout.LayoutParams) mView.getLayoutParams();
-            lp.x = val;
-        }
-    }
-
-    public void setY(Object value) {
-        getScreenSize();
-        int val = mAppRunner.pUtil.sizeToPixels(value, mHeight);
-
-        if (mView.getLayoutParams() instanceof FixedLayout.LayoutParams) {
-            FixedLayout.LayoutParams lp = (FixedLayout.LayoutParams) mView.getLayoutParams();
-            lp.y = val;
-        }
-    }
-
-    private void setWidth(Object value) {
-        getScreenSize();
-        int val = mAppRunner.pUtil.sizeToPixels(value, mWidth);
-
-        if (mView.getLayoutParams() instanceof FixedLayout.LayoutParams) {
-            ViewGroup.LayoutParams lp = mView.getLayoutParams();
-            lp.width = val;
-            mView.setLayoutParams(lp);
-        }
-    }
-
-    private void setHeight(Object value) {
-        getScreenSize();
-        int val = mAppRunner.pUtil.sizeToPixels(value, mHeight);
-
-        if (mView.getLayoutParams() instanceof FixedLayout.LayoutParams) {
-            ViewGroup.LayoutParams lp = mView.getLayoutParams();
-            lp.height = val;
-            mView.setLayoutParams(lp);
         }
     }
 
@@ -319,23 +295,13 @@ public class Styler {
         return ((Number) o).floatValue();
     }
 
-    void getScreenSize() {
-        mWidth = mAppRunner.pUi.screenWidth;
-        mHeight = mAppRunner.pUi.screenHeight;
-    }
-
-    public void setProps(Map o) {
-        mProps.eventOnChange = false;
-        fromTo(o, mProps);
-        apply();
-        mProps.eventOnChange = true;
-    }
-
     public void setLayoutProps(float x, float y, float width, float height) {
-        setX(x);
-        setY(y);
-        setWidth(width);
-        setHeight(height);
+        mProps.eventOnChange = false;
+        mProps.put("x", x);
+        mProps.put("y", y);
+        mProps.put("w", width);
+        mProps.put("h", height);
+        mProps.eventOnChange = true;
     }
 
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/WidgetHelper.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/WidgetHelper.java
@@ -24,6 +24,9 @@ package io.phonk.runner.apprunner.api.widgets;
 import android.view.MotionEvent;
 import android.view.View;
 
+import java.util.Map;
+
+import io.phonk.runner.apprunner.AppRunner;
 import io.phonk.runner.apprunner.api.common.ReturnInterface;
 import io.phonk.runner.apprunner.api.common.ReturnObject;
 
@@ -79,5 +82,61 @@ public class WidgetHelper {
 
     public static void removeMovable(View viewHandler) {
         viewHandler.setOnTouchListener(null);
+    }
+
+    private static void applyLayoutParams(String name, PropertiesProxy props, View view, AppRunner appRunner) {
+        applyLayoutParams(name, props.get(name), props, view, appRunner);
+    }
+
+    public static void applyLayoutParams(String name, Object value, PropertiesProxy props, View view, AppRunner appRunner) {
+        if (name == null) {
+            applyLayoutParams("x", props, view, appRunner);
+            applyLayoutParams("y", props, view, appRunner);
+            applyLayoutParams("w", props, view, appRunner);
+            applyLayoutParams("h", props, view, appRunner);
+
+        } else {
+            if (value == null) return;
+            switch (name) {
+                case "x":
+                    if (view.getLayoutParams() instanceof FixedLayout.LayoutParams) {
+                        ((FixedLayout.LayoutParams) view.getLayoutParams()).x = appRunner.pUtil.sizeToPixels(value, appRunner.pUi.screenWidth);
+                    }
+                    break;
+
+                case "y":
+                    if (view.getLayoutParams() instanceof FixedLayout.LayoutParams) {
+                        ((FixedLayout.LayoutParams) view.getLayoutParams()).y = appRunner.pUtil.sizeToPixels(value, appRunner.pUi.screenHeight);
+                    }
+                    break;
+
+                case "w":
+                    if (view.getLayoutParams() != null) {
+                        view.getLayoutParams().width = appRunner.pUtil.sizeToPixels(value, appRunner.pUi.screenWidth);
+                    }
+                    break;
+
+                case "h":
+                    if (view.getLayoutParams() != null) {
+                        view.getLayoutParams().height = appRunner.pUtil.sizeToPixels(value, appRunner.pUi.screenHeight);
+                    }
+                    break;
+            }
+        }
+    }
+
+    public static void setProps(PropertiesProxy props, Map o) {
+        props.eventOnChange = false;
+        fromTo(o, props);
+        props.eventOnChange = true;
+        props.change();
+    }
+
+    public static void fromTo(Map<String, Object> styleFrom, PropertiesProxy styleTo) {
+        if (styleFrom == null) return;
+
+        for (Map.Entry<String, Object> entry : styleFrom.entrySet()) {
+            styleTo.put(entry.getKey(), styleTo, entry.getValue());
+        }
     }
 }

--- a/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/WidgetHelper.java
+++ b/PHONK-android/phonk_apprunner/src/main/java/io/phonk/runner/apprunner/api/widgets/WidgetHelper.java
@@ -84,16 +84,18 @@ public class WidgetHelper {
         viewHandler.setOnTouchListener(null);
     }
 
-    private static void applyLayoutParams(String name, PropertiesProxy props, View view, AppRunner appRunner) {
-        applyLayoutParams(name, props.get(name), props, view, appRunner);
+    private static void applyViewParam(String name, PropertiesProxy props, View view, AppRunner appRunner) {
+        applyViewParam(name, props.get(name), props, view, appRunner);
     }
 
-    public static void applyLayoutParams(String name, Object value, PropertiesProxy props, View view, AppRunner appRunner) {
+    public static void applyViewParam(String name, Object value, PropertiesProxy props, View view, AppRunner appRunner) {
         if (name == null) {
-            applyLayoutParams("x", props, view, appRunner);
-            applyLayoutParams("y", props, view, appRunner);
-            applyLayoutParams("w", props, view, appRunner);
-            applyLayoutParams("h", props, view, appRunner);
+            applyViewParam("x", props, view, appRunner);
+            applyViewParam("y", props, view, appRunner);
+            applyViewParam("w", props, view, appRunner);
+            applyViewParam("h", props, view, appRunner);
+            applyViewParam("enabled", props, view, appRunner);
+            applyViewParam("visibility", props, view, appRunner);
 
         } else {
             if (value == null) return;
@@ -121,6 +123,14 @@ public class WidgetHelper {
                         view.getLayoutParams().height = appRunner.pUtil.sizeToPixels(value, appRunner.pUi.screenHeight);
                     }
                     break;
+
+                case "enabled":
+                    view.setEnabled(value instanceof Boolean ? (Boolean) value : false);
+                    break;
+
+                case "visibility":
+                    view.setVisibility(view.toString() == "invisible" ? View.INVISIBLE : View.VISIBLE);
+                    break;
             }
         }
     }
@@ -132,11 +142,11 @@ public class WidgetHelper {
         props.change();
     }
 
-    public static void fromTo(Map<String, Object> styleFrom, PropertiesProxy styleTo) {
-        if (styleFrom == null) return;
+    public static void fromTo(Map<String, Object> propsFrom, PropertiesProxy propsTo) {
+        if (propsFrom == null) return;
 
-        for (Map.Entry<String, Object> entry : styleFrom.entrySet()) {
-            styleTo.put(entry.getKey(), styleTo, entry.getValue());
+        for (Map.Entry<String, Object> entry : propsFrom.entrySet()) {
+            propsTo.put(entry.getKey(), entry.getValue());
         }
     }
 }

--- a/PHONK-examples/Graphical User Interface/Linear Layout/main.js
+++ b/PHONK-examples/Graphical User Interface/Linear Layout/main.js
@@ -1,0 +1,79 @@
+function divide(linearLayout, dividerWidth, dividerHeight) {
+  // adds gaps between views
+  var divider = new android.graphics.drawable.ShapeDrawable()
+  divider.setAlpha(0)
+  divider.setIntrinsicWidth(dividerWidth)
+  divider.setIntrinsicHeight(dividerHeight)
+  linearLayout.setDividerDrawable(divider)
+  linearLayout.setShowDividers(android.widget.LinearLayout.SHOW_DIVIDER_MIDDLE)
+  return linearLayout
+}
+
+function info(name, view) {
+  // shows a popup with layout information
+  var s = ''
+  while (true) {
+    var n = view.getClass().getSimpleName()
+    if (n == 'PButton') s += name
+    else if (n == 'PLinearLayout') s += view.props.orientation
+    else break
+
+    var p = view.getLayoutParams()
+    s += ' || w: ' + view.props.w + ', h: ' + view.props.h + ', weight: ' + p.weight + '\n'
+    view = view.getParent()
+  }
+  ui.popup().description(s).show()
+}
+
+
+// make borders visible
+var defaultProps = ui.getProps()
+defaultProps.borderWidth = 1
+defaultProps.borderColor = '#ffffff'
+
+
+ui.addTitle(app.name)
+
+constButton = ui.addButton('Constants', 0.75, 0.02)
+constButton.props.padding = 10
+constButton.onClick(() => ui.popup().description('-1 .. maximum size\n-2 .. minimum size').show())
+
+
+var column = divide(ui.addLinearLayout(0, 0.08, 1, 0.92), 1, 20)
+column.props.padding = 0
+
+
+var topView = divide(ui.newView('linearLayout', {padding: 20}).orientation('horizontal'), 20, 1)
+
+var topLeft = ui.newView('button', {text: 'left'})
+topLeft.onClick(() => info('top left', topLeft))
+topView.add(topLeft, 'top left')  // width: -2 (min), height: -2 (min), weight: 0 (dont' resize)
+
+var topFill = ui.newView('button', {text: 'fill'})
+topFill.onClick(() => info('top fill', topFill))
+topView.add(topFill, 'top fill', 1)  // min width, min height, weight: 1 (resize)
+
+var topRight = ui.newView('button', {text: 'right'})
+topRight.onClick(() => info('top right', topRight))
+topView.add(topRight, 'top right')
+
+column.add(topView, 'top', -1, -2, 0)  // width: -1 (max), height: -2 (min), weight: 0 (don't resize)
+
+
+var fillView = ui.newView('linearLayout', {padding: 10}).orientation('horizontal')
+
+var fillLeft = ui.newView('button', {textAlign: 'right', text: 'fill left, weight: 1'})
+fillLeft.onClick(() => info('fill left', fillLeft))
+fillView.add(fillLeft, 'fill left', -1, -1, 1)
+
+var fillRight = ui.newView('button', {text: 'fill right, weight: 2'})
+fillRight.onClick(() => info('fill right', fillRight))
+fillView.add(fillRight, 'fill right', -1, -1, 2)
+
+column.add(fillView, 'fill', -1, -2, 1)
+
+
+var bottomView = ui.newView('button', {textAlign: 'center', text: 'bottom'})
+bottomView.onClick(() => info('bottom', bottomView))
+
+column.add(bottomView, 'bottom', -1, -2, 0)


### PR DESCRIPTION
Hi,

I didn't consider https://github.com/victordiaz/PHONK/pull/141 final (https://github.com/victordiaz/PHONK/issues/139#issuecomment-1464188735) so this PR partially reverts its changes.

Instead of having separate containers for id, style, layout(, state) as proposed, I found that improving the way changes are applied already provides better separation and fits previous conventions. Essentially
- `PropertiesProxy` (previously `StylePropertiesProxy`) now triggers the changed event with `name == null` when multiple properties changed, and `name != null && value == null` when properties are deleted
- `PropertiesProxy.onChange` is called by widgets instead of `Styler`
- the change callback passes `name` and `value` to various functions: `Styler.apply` and `WidgetHelper.applyLayoutParams`
- the functions either apply everything or only what is necessary

To review this, it is probably better to compare with https://github.com/victordiaz/PHONK/commit/3c4024e447bdde2615403eaa3fc3e65005886590 and consider it a replacement for https://github.com/victordiaz/PHONK/pull/141 which I consider inferior and less backwards compatible. Sorry!

If you agree, I would also add "content" (text, checked, ...) back to props.

*Changes*
- reverted
  - removed id, x, y, w, h from props
  - PViewMethodsInterface: added method id()
  - PUI.getViewById: changed argument type from String to int
  - PViewsArea: removed method addView(PViewMethodsInterface)
- api/widgets: renamed StylePropertiesProxy to PropertiesProxy
- api/PUI: renamed getStyle to getProps
- api/widgets/PropertiesProxy: changed methods remove, putAll, clear to trigger changed event
- api/widgets/PropertiesProxy: added methods change() and change(String, Object)
- api/widgets/PropertiesProxy: implemented methods has, delete, getIds, getDefaultValue, hasInstance
- api/widgets/PropertiesProxy.containsValue: fixed bugs related to calls the wrong method
- api/widgets/PropertiesProxy.put(String, Object): fixed bugs related to doesn't return the previous value
- api/widgets/Styler: added methods apply(String, Object) and apply(String)
- api/widgets/Styler: moved put id to PropertiesProxy()
- api/widgets/Styler: moved methods fromTo and setProps to WidgetHelper
- api/widgets/Styler: removed methods setX, setY, setWidth and setHeight in favor of WidgetHelper.applyLayoutParams
- api/widgets/WidgetHelper: added method applyLayoutParams